### PR TITLE
Post 26B CfP update to telescope resources

### DIFF
--- a/docs/contribution-types/contributed-telescope.rst
+++ b/docs/contribution-types/contributed-telescope.rst
@@ -12,7 +12,7 @@ Unless otherwise noted, this time will be made available via the NOIRLab Time Al
 |Facility            |Location             |Instrumentation          |In-kind                                                                                              |First     |Time       |Duration |
 |                    |                     |                         |Contribution ID                                                                                      |Semester  |Available  |         |
 +====================+=====================+=========================+=====================================================================================================+==========+===========+=========+
-|Gran Canary         | La Palma, Spain     |Imaging and Spectroscopy |`ESP-BCM-S5 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ESP-IAC-S1>`_,      |2026A     |2 nights/  |10 years |
+|Gran Canary         | La Palma, Spain     |Imaging and Spectroscopy |`ESP-BCM-S5 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ESP-IAC-S1>`_,      |TBA       |2 nights/  |10 years |
 |Telescope           |                     |                         |`ESP-IAC-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ESP-IAC-S1>`_       |          |semester   |         |
 |(GTC) 10.4m         |                     |                         |                                                                                                     |          |           |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
@@ -23,10 +23,10 @@ Unless otherwise noted, this time will be made available via the NOIRLab Time Al
 |Subaru              |Maunakea, USA        |Imaging and Spectroscopy |`JAP-JPG-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#JAP-JPG-S1>`_       |2026A     |5 nights/  |10 years |
 |Telescope 8.4m      |                     |                         |                                                                                                     |          |year       |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|Large Binocular     |Mt. Graham, USA      |Imaging and Spectroscopy |`ITA-INA-S18 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ITA-INA-S18>`_     |2026A     |20 hours   |through  |
+|Large Binocular     |Mt. Graham, USA      |Imaging and Spectroscopy |`ITA-INA-S18 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ITA-INA-S18>`_     |2026B     |20 hours   |through  |
 |Telescope 2x8.4m    |                     |                         |                                                                                                     |          |           |FY34     |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|VLT Survey          |Cerro Paranal, Chile |Imaging                  |`ITA-INA-S18 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ITA-INA-S18>`_     |2026A     |35 nights/ |through  |
+|VLT Survey          |Cerro Paranal, Chile |Imaging                  |`ITA-INA-S18 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#ITA-INA-S18>`_     |2026B    |35 nights/ |through  |
 |Telescope 2.6m      |                     |                         |                                                                                                     |          |year       |FY34     |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
 |Nordic Optical      |La Palma, Spain      |Spectroscopic            |`SWE-STK-S3 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#SWE-STK-S3>`_       |2025A     |70 hours/  |2 years  |
@@ -36,7 +36,7 @@ Unless otherwise noted, this time will be made available via the NOIRLab Time Al
 |Two-Meter           |Mexico               |                         |                                                                                                     |          |semester   |         |
 |Telescope 2m        |                     |                         |                                                                                                     |          |           |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|Nishimura 1.8m      |Ōtehīwai Mt John     |Imaging                  |`NZL-AUK-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#NZL-AUK-S1>`_       |2026A     |10 nights/ |10 years |
+|Nishimura 1.8m      |Ōtehīwai Mt John     |Imaging                  |`NZL-AUK-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#NZL-AUK-S1>`_       |TBA       |10 nights/ |10 years |
 |                    |Observatory,         |                         |                                                                                                     |          |semester   |         |
 |                    |New Zealand          |                         |                                                                                                     |          |           |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
@@ -54,15 +54,15 @@ Unless otherwise noted, this time will be made available via the NOIRLab Time Al
 |Telescope 1.4m      |Vidojevca, Serbia    |                         |                                                                                                     |          |month      |         |
 |Telescope 1.4m      |                     |                         |                                                                                                     |          |           |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|Various SAAO        |SAAO, South Africa   |Imaging and Spectroscopy |`SZA-SAA-S4 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#SZA-SAA-S4>`_       |2026A     |26 hours/  |10 years |
+|Various SAAO        |SAAO, South Africa   |Imaging and Spectroscopy |`SZA-SAA-S4 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#SZA-SAA-S4>`_       |TBA       |26 hours/  |10 years |
 |telescopes          |                     |                         |                                                                                                     |          |semester   |         |
 |1.9m - 1.0m         |                     |                         |                                                                                                     |          |           |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|McLellan 1.0m       |Ōtehīwai Mt John     |Imaging                  |`NZL-AUK-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#NZL-AUK-S1>`_       |2026A     |200 equiv  |10 years |
+|McLellan 1.0m       |Ōtehīwai Mt John     |Imaging                  |`NZL-AUK-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#NZL-AUK-S1>`_       |TBA       |200 equiv  |10 years |
 |                    |Observatory,         |                         |                                                                                                     |          |hours      |         |
 |                    |New Zealand          |                         |                                                                                                     |          |Nov-Feb    |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
-|RTT150 1.5m &       |TÜBITAK National     |Imaging                  |`TUR-AKD-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#TUR-AKD-S1>`_       |2026A     |23 nights/ |10 years |
+|RTT150 1.5m &       |TÜBITAK National     |Imaging                  |`TUR-AKD-S1 <https://www.lsst.org/scientists/in-kind-program/telescope-resources#TUR-AKD-S1>`_       |TBA       |23 nights/ |10 years |
 |T100 1.0m           |Observatory, Türkiye |                         |                                                                                                     |          |year total |         |
 +--------------------+---------------------+-------------------------+-----------------------------------------------------------------------------------------------------+----------+-----------+---------+
 
@@ -89,21 +89,6 @@ Fully reduced spectra will be uploaded to WISeREP/TNS within 48 hours of observa
 This contribution was first made available in Semester 2025A and is expected to be available for a total of 4 semesters.
 
 
-Available in Future Semester
-============================
-
-These facilities are expected to be available starting in 2026A.
-
-
-ESP-IAC-S1 and ESP-BCM-S5
--------------------------
-
-Roughly two nights per semester will be available at the Gran Telescope Canaries (GTC).
-The GTC is a 10.4 meter Optical/NIR telescope in La Palma, Spain. The GTC has a wide suite of instrumentation.
-In-kind access to the GTC will not be allocated via the NOIRLab TAC, but a special process to be announced at a later date.
-This contribution is expected to be available for ten years from the starting semester.
-
-
 JAP-JPG-S1
 ----------
 
@@ -118,6 +103,35 @@ KOR-KAS-S2
 Roughly 150 hours per semester will be available on each of the telescopes of the `Korean Microlensing Telescope Network <https://kmtnet.kasi.re.kr/kmtnet-eng/>`_.
 KMTNet consists of 1.6 meter optical imaging telescopes located in Cerro Tololo, Chile, Siding Springs Observatory, Australia, and South African Astronomical Observatory, South Africa.
 This contribution is expected to be available for 5 years after the first semster.
+
+
+SZA-SAA-S1
+----------
+
+25 hours per semester will be available on the 9.2 meter `South African Large Telescope <https://astronomers.salt.ac.za/>`_ located at South African Astronomical Observatory, South Africa.
+SALT has a wide range of `SALT instrumentation <https://astronomers.salt.ac.za/instruments/>`_ available. This contribution is expected to be available for 10 years from the start of the first semester of availability.
+
+
+ITA-INA-S18
+-----------
+
+35 pre-allocated nights per year will be available at the 2.6 meter `VLT Survey Telescope <https://www.eso.org/sci/facilities/paranal/telescopes/vst.html>`_ at Paranal, Chile for imaging observations.
+20 hours of open-shutter time per year will be available at the twin 8.4 telescopes at the `Large Binocular Telescope Observatory <https://www.lbto.org/>`_ with
+the suite of imaging and spectroscopy instrumentation available. This contribution is expected to be available through FY2034.
+
+
+Available in a Future Semester
+============================
+
+
+
+ESP-IAC-S1 and ESP-BCM-S5
+-------------------------
+
+Roughly two nights per semester will be available at the Gran Telescope Canaries (GTC).
+The GTC is a 10.4 meter Optical/NIR telescope in La Palma, Spain. The GTC has a wide suite of instrumentation.
+In-kind access to the GTC will not be allocated via the NOIRLab TAC, but a special process to be announced at a later date.
+This contribution is expected to be available for ten years from the starting semester.
 
 
 NZL-AUK-S1
@@ -135,27 +149,12 @@ Twenty nights per semester will be available at the Trans-Pacific Two-Meter Tele
 This project is expected to undergo first light and commissioning in 2025. The contribution is expected to be available for 10 years from the first semester of availability.
 
 
-SZA-SAA-S1
-----------
-
-25 hours per semester will be available on the 9.2 meter `South African Large Telescope <https://astronomers.salt.ac.za/>`_ located at South African Astronomical Observatory, South Africa.
-SALT has a wide range of `SALT instrumentation <https://astronomers.salt.ac.za/instruments/>`_ available. This contribution is expected to be available for 10 years from the start of the first semester of availability.
-
-
 SZA-SAA-S4
 ----------
 
 Approximately 26 hours per semester will be available on a network of telescopes available at the South African Astronomical Observatory, South Africa.
 Telescopes will include the `1.0 meter <https://www.saao.ac.za/astronomers/1-0m/>`_ and `1.9 meter <https://www.saao.ac.za/astronomers/1-9m/>`_ facilities.
 This contribution is expected to be available for 10 years from the start of the first semester of availability.
-
-
-ITA-INA-S18
------------
-
-35 pre-allocated nights per year will be available at the 2.6 meter `VLT Survey Telescope <https://www.eso.org/sci/facilities/paranal/telescopes/vst.html>`_ at Paranal, Chile for imaging observations.
-20 hours of open-shutter time per year will be available at the twin 8.4 telescopes at the `Large Binocular Telescope Observatory <https://www.lbto.org/>`_ with
-the suite of imaging and spectroscopy instrumentation available. This contribution is expected to be available through FY2034.
 
 
 TUR-AKD-S1


### PR DESCRIPTION
Updated post 2026B CfP with correct start dates, updated future vs. now available. No major content changes.