### PR TITLE
Rebuild Contributed Datasets page as a filterable, sortable catalog

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,3 +1,11 @@
+import datetime
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
 from documenteer.conf.guide import *  # noqa: F401 F403
 
 html_theme_options = {
@@ -9,4 +17,147 @@ linkcheck_ignore = [
     r'https://astronomers\.salt\.ac\.za/.*',
     r'https://vidojevica\.aob\.rs/.*',
 ]
+
+
+# ============================================================================
+# Contributed Datasets page data loading
+#
+# Each dataset record lives as a YAML file in
+# docs/contribution-types/_data/datasets/<contribution-id>.yaml, split into
+# a `form_data` section (owned by the CSV pull script; safe to overwrite)
+# and a `curated` section (hand-edited only; the pull script never touches
+# it). This loader reads all records, resolves each one's display status,
+# and exposes them to the contributed-datasets.rst page via sphinx_jinja.
+# ============================================================================
+
+def _slugify(value):
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _normalize_strings(obj):
+    """Recursively collapse embedded/trailing newlines and extra whitespace.
+
+    YAML block scalars (`>` or `|`) can leave a trailing newline, or authors
+    may wrap long strings across lines. Any such string ends up substituted
+    inline into HTML attributes and RST directive arguments by the Jinja
+    template; a stray unindented newline there breaks the surrounding
+    `.. raw:: html` block (or the directive line), so every string value is
+    normalized to a single line with collapsed whitespace at load time.
+    """
+    if isinstance(obj, str):
+        return " ".join(obj.split())
+    if isinstance(obj, list):
+        return [_normalize_strings(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _normalize_strings(v) for k, v in obj.items()}
+    return obj
+
+
+def _last_updated(path):
+    """Best-effort "last updated" date for a single dataset record file.
+
+    Prefers the file's most recent git commit date (accurate and portable
+    across clones once the file has been committed). Falls back to the
+    file's on-disk modification time for files that haven't been committed
+    yet (e.g. during local review before a PR), so the page always shows
+    something rather than a blank field.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%cs", "--", path.name],
+            cwd=path.parent,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        date_str = result.stdout.strip()
+        if date_str:
+            return date_str
+    except Exception:
+        pass
+    try:
+        return datetime.date.fromtimestamp(path.stat().st_mtime).isoformat()
+    except Exception:
+        return None
+
+
+def _load_contributed_datasets():
+    data_dir = (
+        Path(__file__).parent
+        / "docs"
+        / "contribution-types"
+        / "_data"
+        / "datasets"
+    )
+    records = []
+    all_data_types = set()
+    all_wavelengths = set()
+    all_uat = set()
+    for path in sorted(data_dir.glob("*.yaml")):
+        with path.open() as f:
+            record = yaml.safe_load(f) or {}
+        record = _normalize_strings(record)
+        form_data = record.setdefault("form_data", {}) or {}
+        curated = record.setdefault("curated", {}) or {}
+        status_override = curated.get("status_override")
+        if status_override:
+            status = status_override
+        else:
+            status = "available" if form_data.get("submitted") else "not_yet_delivered"
+        record["status"] = status
+
+        data_types = form_data.get("data_type") or []
+        wavelengths = curated.get("wavelength_regime") or []
+        uat_categories = form_data.get("uat_category") or []
+        all_data_types.update(data_types)
+        all_wavelengths.update(wavelengths)
+        all_uat.update(uat_categories)
+
+        cid_slug = _slugify(record.get("contribution_id", ""))
+        record["cid_slug"] = cid_slug
+        record["last_updated"] = _last_updated(path)
+
+        # Space-separated CSS-safe tokens used by the page's filter/sort
+        # script to match table rows and cards against the active filters.
+        # cid- lets the free-text search script look a row/card back up in
+        # the search index below without needing a raw data-* attribute on
+        # sphinx-design's card markup (which only accepts CSS classes).
+        tokens = [f"status-{_slugify(status)}", f"cid-{cid_slug}"]
+        tokens += [f"dt-{_slugify(v)}" for v in data_types]
+        tokens += [f"wl-{_slugify(v)}" for v in wavelengths]
+        tokens += [f"uat-{_slugify(v)}" for v in uat_categories]
+        record["filter_tokens"] = " ".join(tokens)
+
+        # Free-text search covers the title, the curated summary/blurb, the
+        # primary recipient, and the data type / wavelength / UAT "keyword"
+        # tags -- lowercased for a simple case-insensitive substring search.
+        search_parts = [
+            record.get("title", ""),
+            curated.get("summary", "") or "",
+            curated.get("primary_recipient", "") or "",
+            *data_types,
+            *wavelengths,
+            *uat_categories,
+        ]
+        record["search_text"] = " ".join(search_parts).lower()
+
+        records.append(record)
+    # Reverse chronological by last-updated -- the most recently touched
+    # contributions surface first, since that's the signal visitors care
+    # about. Missing dates sort to the bottom rather than the top.
+    records.sort(key=lambda r: r.get("last_updated") or "", reverse=True)
+    search_index = {r["cid_slug"]: r["search_text"] for r in records}
+    return {
+        "datasets": records,
+        "all_data_types": sorted(all_data_types),
+        "all_wavelengths": sorted(all_wavelengths),
+        "all_uat": sorted(all_uat),
+        "slugify": _slugify,
+        "search_index_json": json.dumps(search_index),
+    }
+
+
+jinja_contexts = {
+    "contributed_datasets": _load_contributed_datasets(),
+}
 

--- a/docs/contribution-types/_data/datasets/GER-MPE-S3.yaml
+++ b/docs/contribution-types/_data/datasets/GER-MPE-S3.yaml
@@ -1,0 +1,41 @@
+contribution_id: GER-MPE-S3
+title: The LSST sources detected by eROSITA
+country: Germany
+institute: MPE
+
+# --- fields the CSV pull script owns; safe to overwrite on every sync ---
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Value-Added Catalogs]  # backfilled guess, not from a real submission yet
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [High energy astrophysics]  # backfilled guess
+  uat_concepts: null
+
+# --- fields only a human edits; the pull script never touches these ---
+curated:
+  primary_recipient: LSST AGN Science Collaboration
+  target_audience: null
+  summary: >
+    MPE will generate and curate eROSITA-LSST value-added catalogs for the
+    AGN that the LSST collaboration will identify, using public eROSITA
+    data that MPE itself is responsible for.
+  wavelength_regime: [X-ray, Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ISR-UST-S2.yaml
+++ b/docs/contribution-types/_data/datasets/ISR-UST-S2.yaml
@@ -1,0 +1,41 @@
+contribution_id: ISR-UST-S2
+title: ULTRASAT all-sky UV maps
+country: Israel
+institute: UST
+
+# --- fields the CSV pull script owns; safe to overwrite on every sync ---
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Imaging / Cutouts]  # backfilled guess, not from a real submission yet
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Observational astronomy]  # backfilled guess -- ambiguous, flagged for review
+  uat_concepts: null
+
+# --- fields only a human edits; the pull script never touches these ---
+curated:
+  primary_recipient: NOIRLab CSDC
+  target_audience: null
+  summary: >
+    Rubin community will have access to the ULTRASAT all-sky map produced in
+    the first six-months of operation for at least 12 months prior to the
+    public data release.
+  wavelength_regime: [UV]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ITA-INA-S16.yaml
+++ b/docs/contribution-types/_data/datasets/ITA-INA-S16.yaml
@@ -1,0 +1,39 @@
+contribution_id: ITA-INA-S16
+title: "The Son of X-Shooter contribution to Rubin: 2,000 spectra for Machine Learning light curve classification"
+country: Italy
+institute: INAF
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra, Machine Learning Training Sets]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Observational astronomy]  # backfilled guess -- ambiguous, SOXS spans UV-NIR and is used for transient classification; flagged for review
+  uat_concepts: null
+
+curated:
+  primary_recipient: TVS
+  target_audience: null
+  summary: >
+    INAF will deliver 2,000 spectra obtained with SOXS from LSST targets.
+    Deliverables are the entire data acquired for the targets, including
+    1-D extracted spectra and spectral classification.
+  wavelength_regime: [Optical, NIR]  # ambiguous -- SOXS technically spans UV to NIR, flagged for review
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ITA-INA-S17.yaml
+++ b/docs/contribution-types/_data/datasets/ITA-INA-S17.yaml
@@ -1,0 +1,41 @@
+contribution_id: ITA-INA-S17
+title: A Cluster Spectroscopy Hub for galaxy cluster science with LSST
+country: Italy
+institute: INAF
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Galactic and extragalactic astronomy]  # updated after Steve corrected the form's UAT list to the real 11 top-level branches -- galaxy cluster science fits this better than Cosmology
+  uat_concepts: null
+
+curated:
+  primary_recipient: NOIRLab CSDC
+  target_audience: null
+  summary: >
+    We propose to share a vast spectroscopic database on galaxy clusters,
+    complemented with physical metadata and other imaging (ground-based and
+    HST) data-products, with the LSST community, effectively creating a
+    Cluster Spectroscopy Hub for the exploitation of LSST data for a range
+    of cluster science cases.
+  wavelength_regime: [Optical]  # ambiguous -- includes some HST imaging, which could add UV/NIR; flagged for review
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ITA-INA-S27.yaml
+++ b/docs/contribution-types/_data/datasets/ITA-INA-S27.yaml
@@ -1,0 +1,41 @@
+contribution_id: ITA-INA-S27
+title: A VST survey to support the Legacy Survey of Space and Time
+country: Italy
+institute: INAF
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Time-Series / Lightcurves, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    We propose to use 80 nights/year of VST time from 2026 until 2032 (with
+    a possible extension to 2036) to execute a support survey with VST, to
+    complement the LSST dataset improving the light curve sampling of
+    transient and variable sources, and to deliver the data to the
+    US/Chilean communities before they are made public.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ITA-INA-S28.yaml
+++ b/docs/contribution-types/_data/datasets/ITA-INA-S28.yaml
@@ -1,0 +1,41 @@
+contribution_id: ITA-INA-S28
+title: "Exploiting the synergy between LSST and VST: the expansion rate and geometry of the Universe measured through time delays of strongly lensed variable sources"
+country: Italy
+institute: INAF
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Time-Series / Lightcurves, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess -- strong-lensing time-delay cosmography
+  uat_concepts: null
+
+curated:
+  primary_recipient: SLSC
+  target_audience: null
+  summary: >
+    We propose to use 4620 hours (i.e., 577.5 nights) of VST time over 7
+    years to complement the LSST dataset improving the light curve
+    sampling of transient and variable sources strongly lensed by galaxies
+    and galaxy clusters, and to deliver the data to the US/Chilean
+    communities before they are made public.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/ITA-INA-S29.yaml
+++ b/docs/contribution-types/_data/datasets/ITA-INA-S29.yaml
@@ -1,0 +1,41 @@
+contribution_id: ITA-INA-S29
+title: "Toward next-generation time-domain surveys (TIMEDOMES): VST monitoring of the LSST Deep Drilling Fields"
+country: Italy
+institute: INAF
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Imaging / Cutouts, Value-Added Catalogs, Time-Series / Lightcurves]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [High energy astrophysics]  # backfilled guess -- primary recipient is the AGN Science Collaboration
+  uat_concepts: null
+
+curated:
+  primary_recipient: LSST AGN Science Collaboration
+  target_audience: null
+  summary: >
+    We propose to use 170 hours/year of VST time to execute a precursor
+    survey with VST, to complement and extend in time the LSST dataset on
+    4 DDF, and to combine these observations with all archival data to
+    deliver reduced images, catalogs and lightcurves lasting up to >10
+    years to the US/Chilean communities.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/JAP-JPG-S10.yaml
+++ b/docs/contribution-types/_data/datasets/JAP-JPG-S10.yaml
@@ -1,0 +1,39 @@
+contribution_id: JAP-JPG-S10
+title: Subaru PFS spectroscopic follow-up survey of LSST transients in deep drilling fields
+country: Japan
+institute: Japan Participation Group (JPG)  # institute full name inferred, flagged for confirmation
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess -- ambiguous, could be Observational astronomy instead; flagged for review
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    JPG will deliver the data products from the Subaru PFS spectroscopic
+    follow-up survey of LSST transients in drilling fields, to be ingested
+    into Kavli IPMU Lite IDAC.
+  wavelength_regime: [Optical, NIR]  # PFS covers optical through near-infrared
+  status_override: null

--- a/docs/contribution-types/_data/datasets/JAP-JPG-S11.yaml
+++ b/docs/contribution-types/_data/datasets/JAP-JPG-S11.yaml
@@ -1,0 +1,42 @@
+contribution_id: JAP-JPG-S11
+title: Subaru PFS filler survey for LSST photo-z training dataset
+country: Japan
+institute: Japan Participation Group (JPG)  # institute full name inferred, flagged for confirmation
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra, Machine Learning Training Sets]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess -- photo-z calibration supports cosmology
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    The activity offered by JPG would involve the development of a target
+    selection algorithm in close collaboration with the Rubin Photo-z
+    Coordination Group and/or DESC, the observation and data analysis, the
+    ingestion of the dataset into Kavli IPMU Lite IDAC with NOIRLab CSDC,
+    and finally the scientific application of the dataset to improve
+    photo-z accuracy of LSST photometric redshifts.
+  wavelength_regime: [Optical, NIR]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/JAP-JPG-S12.yaml
+++ b/docs/contribution-types/_data/datasets/JAP-JPG-S12.yaml
@@ -1,0 +1,39 @@
+contribution_id: JAP-JPG-S12
+title: Contribution to the LSST photo-z calibration with the PFS-SSP galaxy evolution dataset
+country: Japan
+institute: Japan Participation Group (JPG)  # institute full name inferred, flagged for confirmation
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra, Machine Learning Training Sets]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    JPG will deliver the data products of PFS-SSP, based upon approval
+    from the PFS-SSP team, to the LSST community for photo-z calibration
+    and training datasets.
+  wavelength_regime: [Optical, NIR]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/NZL-AUK-S2.yaml
+++ b/docs/contribution-types/_data/datasets/NZL-AUK-S2.yaml
@@ -1,0 +1,43 @@
+contribution_id: NZL-AUK-S2
+title: "The MOA Archive: two decades of Galactic Bulge and Magellanic Clouds photometry"
+country: New Zealand
+institute: Auckland
+
+# --- fields the CSV pull script owns; safe to overwrite on every sync ---
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Time-Series / Lightcurves, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Galactic and extragalactic astronomy]  # relabeled to match the form's corrected 11 official top-level UAT branches
+  uat_concepts: null
+
+# --- fields only a human edits; the pull script never touches these ---
+curated:
+  primary_recipient: NOIRLab
+  target_audience: null
+  summary: >
+    The MOA archive will be ingested into a locally maintained server that
+    will provide image cutouts at the start of the LSST survey and machine
+    calibrated photometry 12 months after the beginning of the survey,
+    giving high cadence coverage of the Galactic Bulge and Magellanic
+    Clouds dating back to 2006.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/SWE-STK-S4.yaml
+++ b/docs/contribution-types/_data/datasets/SWE-STK-S4.yaml
@@ -1,0 +1,43 @@
+contribution_id: SWE-STK-S4
+title: "Supernova Lightcurves and low-resolution spectra for Full-sky Low-redshift Cosmography Complementing LSST"
+country: Sweden
+institute: Stockholm University
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Time-Series / Lightcurves, Spectra]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess -- title explicitly says "cosmography"
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    SU will provide online data file access (anticipated to be hosted at
+    NOIRLab) whereby it is possible for LSST users to download the
+    photometry and spectroscopy tables for each ZTF/ZTF-II SN (or the
+    entire set at once), as well as the ancillary information about the
+    host galaxy environment. We will provide machine readable files,
+    including standard formats used by lightcurve fitters (SALT2, SNooPy)
+    and FITS tables.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/SZA-SAA-S2.yaml
+++ b/docs/contribution-types/_data/datasets/SZA-SAA-S2.yaml
@@ -1,0 +1,39 @@
+contribution_id: SZA-SAA-S2
+title: MeerKAT high-level data products and services for LSST
+country: South Africa
+institute: South African Astronomical Observatory (SAA)  # institute full name inferred, flagged for confirmation
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Imaging / Cutouts, Value-Added Catalogs]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Galactic and extragalactic astronomy]  # updated -- the form's UAT list now has this branch, a direct fit given the Galaxies Science Collaboration recipient
+  uat_concepts: null
+
+curated:
+  primary_recipient: Galaxies Science Collaboration
+  target_audience: null
+  summary: >
+    South Africa will produce reduced high-level data products (images and
+    catalogs) and services for MeerKAT data, as endorsed by the Galaxies
+    Science Collaboration, integrated into the Rubin Science Platform.
+  wavelength_regime: [Radio]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/UKD-OXF-S7.yaml
+++ b/docs/contribution-types/_data/datasets/UKD-OXF-S7.yaml
@@ -1,0 +1,42 @@
+contribution_id: UKD-OXF-S7
+title: LSST-matched MIGHTEE data
+country: United Kingdom
+institute: University of Oxford
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Value-Added Catalogs, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Galactic and extragalactic astronomy]  # updated -- the form's UAT list now has this branch, which is a direct fit for MIGHTEE's extragalactic HI/continuum survey
+  uat_concepts: null
+
+curated:
+  primary_recipient: NOIRLab CSDC
+  target_audience: null
+  summary: >
+    The activity offered by Oxford would involve installation of the
+    MIGHTEE Survey data at the UK DAC, and subsequently, joint work with
+    the LSST Science Collaborations in training photo-z (based on HI data
+    and the incorporation of radio continuum and polarisation data) as
+    well as user support for the LSST Science Community to facilitate the
+    use of the Survey data.
+  wavelength_regime: [Radio]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/UKD-UKD-S10.yaml
+++ b/docs/contribution-types/_data/datasets/UKD-UKD-S10.yaml
@@ -1,0 +1,43 @@
+contribution_id: UKD-UKD-S10
+title: "Science Software development: spectroscopic classification of transients and 4MOST spectra"
+country: United Kingdom
+institute: LSST:UK
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Spectra]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Cosmology]  # backfilled guess -- ambiguous, could be Observational astronomy given the time-domain/transient focus; flagged for review
+  uat_concepts: null
+
+curated:
+  primary_recipient: DESC
+  target_audience: null
+  summary: >
+    To provide non-directable software development effort to the LSST
+    DESC for transient spectroscopic follow-up, developing software to
+    ensure successful scheduling and observation of transients and their
+    host galaxies by 4MOST, and the return of the transient types and
+    redshifts to the collaboration (through the Lasair broker, within
+    24hrs) and the final calibrated spectra as contributed data sets on
+    an annual basis.
+  wavelength_regime: [Optical]
+  status_override: null

--- a/docs/contribution-types/_data/datasets/UKD-UKD-S5.yaml
+++ b/docs/contribution-types/_data/datasets/UKD-UKD-S5.yaml
@@ -1,0 +1,41 @@
+contribution_id: UKD-UKD-S5
+title: "Science Software development: Near infrared data fusion"
+country: United Kingdom
+institute: LSST:UK
+
+form_data:
+  submitted: false
+  email: null
+  name: null
+  target_audience: null
+  contribution_summary: null
+  version: null
+  data_type: [Value-Added Catalogs, Imaging / Cutouts]  # backfilled guess
+  data_volume: null
+  data_schema_link: null
+  hosting_location: null
+  access_url: null
+  access_mechanisms: []
+  authentication: null
+  generation_methods: null
+  validation_limitations: null
+  tutorials_docs: null
+  support_channel: null
+  citation: null
+  maintenance_plan: null
+  maintenance_notes: null
+  final_report: null
+  uat_category: [Observational astronomy]  # backfilled guess -- ambiguous, this is a generic pipeline/data-fusion effort with no stated science case; flagged for review
+  uat_concepts: null
+
+curated:
+  primary_recipient: NOIRLab CSDC
+  target_audience: null
+  summary: >
+    LSST:UK will provide joint LSST+VISTA near infra-red catalogues
+    produced using the LSST Stack and access to VISTA survey images as a
+    dataset contribution, as well as an implementation of the LSST Stack
+    pipeline reconfigured to jointly process LSST pixels with external
+    survey pixels.
+  wavelength_regime: [Optical, NIR]
+  status_override: null

--- a/docs/contribution-types/contributed-datasets.rst
+++ b/docs/contribution-types/contributed-datasets.rst
@@ -2,136 +2,236 @@
 Contributed Datasets
 ####################
 
-This webpage lists the complementary data sets expected to be made available to the Rubin Community via the Vera C. Rubin In-kind Program.
-For each contribution, the title, a summary, and the primary recipient of the contribution are provided.
-The majority of the contributions have not yet started, or are in an early phase. This information will be periodically updated as the datasets become available.
+The Vera C. Rubin Observatory In-Kind Program includes contributed datasets: complementary data products that international partners make available to the Rubin community in exchange for data rights.
+This page lists all current dataset contributions, helping the Rubin and NOIRLab community discover data relevant to their research.
+
+Use the filters or the table below to browse by data type, wavelength regime, or science case.
+Each entry links to a fuller record with access details, documentation, and citation information once a dataset is ready to share.
+Most contributions are still pre-delivery; those are clearly marked and will be filled in as datasets become available.
 
 Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have any questions about contributed datasets.
 
+.. jinja:: contributed_datasets
 
-**The LSST sources detected by eROSITA (GER-MPE-S3)**
+   .. raw:: html
 
-MPE will generate and curate eROSITA-LSST value-added catalogs for the AGN that the LSST collaboration will identify, using public eROSITA data that MPE itself is responsible for.
+      <style>
+        .ikc-filterbar { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem; }
+        .ikc-filterbar label { font-size: 0.9em; }
+        .ikc-datasets-table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
+        .ikc-datasets-table th, .ikc-datasets-table td { text-align: left; padding: 0.5em 0.75em; border-bottom: 1px solid #ddd; }
+        .ikc-datasets-table th { cursor: pointer; user-select: none; }
+        .ikc-badge { display: inline-block; padding: 0.15em 0.6em; border-radius: 1em; font-size: 0.85em; }
+        .ikc-badge-success { background: #d9f2e3; color: #1a5c33; }
+        .ikc-badge-muted { background: #e6e6e6; color: #555; }
+        .ikc-toggle-btn { padding: 0.4em 0.9em; border-radius: 1em; border: 1px solid #999; background: #fff; color: #1a1a1a; cursor: pointer; font-size: 0.9em; white-space: nowrap; }
+        .ikc-toggle-btn[aria-pressed="true"] { background: #1a5c33; border-color: #1a5c33; color: #fff; }
+        .ikc-actionbar { display: flex; flex-wrap: wrap; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+        .ikc-actionbar input[type="text"] { flex: 1; min-width: 220px; padding: 0.4em 0.6em; border: 1px solid #999; border-radius: 0.3em; font-size: 0.9em; }
+        .ikc-title-link { color: inherit; text-decoration: none; cursor: pointer; background: none; border: none; padding: 0; font: inherit; text-align: left; }
+        .ikc-title-link:hover { text-decoration: underline; }
+        .ikc-card.ikc-highlight .sd-card { outline: 3px solid #1a5c33; outline-offset: 2px; transition: outline-color 1.2s ease; }
+      </style>
 
-Primary Recipient: LSST AGN Science Collaboration
+      <div class="ikc-filterbar">
+        <label>Data type
+          <select id="ikc-filter-dt">
+            <option value="">All</option>
+            {% for v in all_data_types %}<option value="dt-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Wavelength
+          <select id="ikc-filter-wl">
+            <option value="">All</option>
+            {% for v in all_wavelengths %}<option value="wl-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Science case (UAT)
+          <select id="ikc-filter-uat">
+            <option value="">All</option>
+            {% for v in all_uat %}<option value="uat-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+      </div>
 
+      <div class="ikc-actionbar">
+        <input type="text" id="ikc-search" placeholder="Search title, description, keywords...">
+        <button type="button" id="ikc-toggle-status" class="ikc-toggle-btn" aria-pressed="false">Show available only</button>
+      </div>
 
-**ULTRASAT all-sky UV maps (ISR-UST-S2)**
+      <table class="ikc-datasets-table" id="ikc-datasets-table">
+        <thead>
+          <tr>
+            <th data-sort="title">Dataset</th>
+            <th data-sort="datatype">Data type</th>
+            <th data-sort="wavelength">Wavelength</th>
+            <th data-sort="recipient">Primary recipient</th>
+            <th data-sort="status">Status</th>
+            <th data-sort="updated">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for ds in datasets %}
+          <tr class="ikc-row" data-tokens="{{ ds.filter_tokens }}"
+              data-title="{{ ds.title }}"
+              data-datatype="{{ (ds.form_data.data_type or []) | join(', ') }}"
+              data-wavelength="{{ (ds.curated.wavelength_regime or []) | join(', ') }}"
+              data-recipient="{{ ds.curated.primary_recipient or '' }}"
+              data-status="{{ ds.status }}"
+              data-updated="{{ ds.last_updated or '' }}">
+            <td><button type="button" class="ikc-title-link" data-cid="{{ ds.cid_slug }}">{{ ds.title }} ({{ ds.contribution_id }})</button></td>
+            <td>{{ (ds.form_data.data_type or []) | join(', ') or 'TBD' }}</td>
+            <td>{{ (ds.curated.wavelength_regime or []) | join(', ') or 'TBD' }}</td>
+            <td>{{ ds.curated.primary_recipient or 'TBD' }}</td>
+            <td>{% if ds.status == 'available' %}<span class="ikc-badge ikc-badge-success">Available</span>{% else %}<span class="ikc-badge ikc-badge-muted">Not yet delivered</span>{% endif %}</td>
+            <td>{{ ds.last_updated or 'unknown' }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-Rubin community will have access to the ULTRASAT all-sky map produced in the first six-months of operation for at least 12 months prior to the public data release
+      <script>
+      (function () {
+        var SEARCH_INDEX = {{ search_index_json }};
+        var CID_RE = /cid-([a-z0-9-]+)/;
+        var showAvailableOnly = false;
 
-Primary Recipient: NOIRLab CSDC
+        function matchesSearch(tokens) {
+          var query = document.getElementById('ikc-search').value.trim().toLowerCase();
+          if (!query) { return true; }
+          var m = CID_RE.exec(tokens);
+          var text = m ? (SEARCH_INDEX[m[1]] || '') : '';
+          return text.indexOf(query) !== -1;
+        }
 
+        function setVisible(el, visible) {
+          // sphinx-design's grid-item wrapper carries a `display: flex
+          // !important` class (.sd-d-flex-row), which beats a plain inline
+          // `style="display:none"`. Setting the inline override with
+          // !important priority is the only thing that reliably wins.
+          if (visible) {
+            el.style.removeProperty('display');
+          } else {
+            el.style.setProperty('display', 'none', 'important');
+          }
+        }
 
-**The Son of X-Shooter contribution to Rubin: a set of 2,000 spectra for Machine Learning light curve classification (ITA-INA-S16)**
+        function applyFilters() {
+          var dt = document.getElementById('ikc-filter-dt').value;
+          var wl = document.getElementById('ikc-filter-wl').value;
+          var uat = document.getElementById('ikc-filter-uat').value;
+          var filters = [dt, wl, uat].filter(Boolean);
+          if (showAvailableOnly) { filters.push('status-available'); }
+          document.querySelectorAll('.ikc-row').forEach(function (row) {
+            var tokenStr = row.getAttribute('data-tokens');
+            var tokens = ' ' + tokenStr + ' ';
+            var visible = filters.every(function (f) { return tokens.indexOf(' ' + f + ' ') !== -1; })
+              && matchesSearch(tokenStr);
+            setVisible(row, visible);
+          });
+          document.querySelectorAll('.ikc-card').forEach(function (card) {
+            var tokenStr = card.className;
+            var tokens = ' ' + tokenStr + ' ';
+            var visible = filters.every(function (f) { return tokens.indexOf(' ' + f + ' ') !== -1; })
+              && matchesSearch(tokenStr);
+            setVisible(card, visible);
+          });
+        }
+        ['ikc-filter-dt', 'ikc-filter-wl', 'ikc-filter-uat'].forEach(function (id) {
+          var el = document.getElementById(id);
+          if (el) el.addEventListener('change', applyFilters);
+        });
+        var searchInput = document.getElementById('ikc-search');
+        if (searchInput) { searchInput.addEventListener('input', applyFilters); }
 
-INAF will deliver 2,000 spectra obtained with SOXS from LSST targets. Deliverables are the entire data acquired for the targets, including 1-D extracted spectra and spectral classification.
+        var toggleBtn = document.getElementById('ikc-toggle-status');
+        if (toggleBtn) {
+          toggleBtn.addEventListener('click', function () {
+            showAvailableOnly = !showAvailableOnly;
+            toggleBtn.setAttribute('aria-pressed', showAvailableOnly ? 'true' : 'false');
+            toggleBtn.textContent = showAvailableOnly ? 'Include future datasets' : 'Show available only';
+            applyFilters();
+          });
+        }
 
-Primary Recipient: TVS
+        document.querySelectorAll('.ikc-title-link').forEach(function (link) {
+          link.addEventListener('click', function () {
+            var cid = link.getAttribute('data-cid');
+            var card = document.querySelector('.ikc-card.cid-' + cid);
+            if (!card) { return; }
+            card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            card.classList.add('ikc-highlight');
+            setTimeout(function () { card.classList.remove('ikc-highlight'); }, 1500);
+          });
+        });
 
+        var sortState = {};
+        document.querySelectorAll('#ikc-datasets-table th[data-sort]').forEach(function (th) {
+          th.addEventListener('click', function () {
+            var key = th.getAttribute('data-sort');
+            var tbody = document.querySelector('#ikc-datasets-table tbody');
+            var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+            var asc = !sortState[key];
+            sortState = {};
+            sortState[key] = asc;
+            rows.sort(function (a, b) {
+              var av = a.getAttribute('data-' + key) || '';
+              var bv = b.getAttribute('data-' + key) || '';
+              return asc ? av.localeCompare(bv) : bv.localeCompare(av);
+            });
+            rows.forEach(function (r) { tbody.appendChild(r); });
+          });
+        });
+      })();
+      </script>
 
-**A Cluster Spectroscopy Hub for galaxy cluster science with LSST (ITA-INA-S17)**
+   .. grid:: 1 1 2 2
+      :gutter: 2
 
-We propose to share a vast spectroscopic database on galaxy clusters, complemented with physical metadata and other imaging (ground-based and HST) data-products, with the LSST community,
-effectively creating a Cluster Spectroscopy Hub for the exploitation of LSST data for a range of cluster science cases.
+      {% for ds in datasets %}
+      {% if ds.status == 'available' %}
+      .. grid-item-card:: {{ ds.title }}
+          :class-item: ikc-card {{ ds.filter_tokens }}
 
-Primary Recipient: NOIRLab CSDC
+          {{ ds.contribution_id }} - {{ ds.country }}
+          ^^^
+          {% for dt in (ds.form_data.data_type or []) %}:bdg-light:`{{ dt }}` {% endfor %}{% for wl in (ds.curated.wavelength_regime or []) %}:bdg-light:`{{ wl }}` {% endfor %}{% for uc in (ds.form_data.uat_category or []) %}:bdg-light:`{{ uc }}` {% endfor %}
 
+          **Primary recipient:** {{ ds.curated.primary_recipient or 'TBD' }}
 
-**A VST surveys to support the Legacy Survey of Space and Time (ITA-INA-S27)**
+          **Target audience:** {{ ds.curated.target_audience or 'TBD' }}
 
-We propose to use 80 nights/year of VST time from 2026 until 2032 (with a possible extension to 2036) to execute a support survey with VST,
-to complement the LSST dataset improving the light curve sampling of transient and variable sources, and to deliver the data to the US/Chilean communities before they are made public.
+          {{ ds.curated.summary or 'TBD' }}
 
-Primary Recipient: DESC
+          **Data volume:** {{ ds.form_data.data_volume or 'TBD' }}
 
+          **Hosting location:** {{ ds.form_data.hosting_location or 'TBD' }}
 
-**Exploiting the synergy between LSST and VST to investigate the cosmos: the expansion rate and the geometry of the Universe measured through the time delays of strongly lensed variable sources. (ITA-INA-S28)**
+          **Access:** {{ ds.form_data.access_url or 'TBD' }}
 
-We propose to use 4620 hours (i.e., 577.5 nights) of VST time over 7 years to complement the LSST dataset improving the light curve sampling of transient
-and variable sources strongly lensed by galaxies and galaxy clusters, and to deliver the data to the US/Chilean communities before they are made public.
+          **Documentation:** {{ ds.form_data.tutorials_docs or 'TBD' }}
 
-Primary Recipient: SLSC
+          **Support channel:** {{ ds.form_data.support_channel or 'TBD' }}
 
+          **Citation:** {{ ds.form_data.citation or 'TBD' }}
 
-**Toward next-generation time-domain surveys (TIMEDOMES): VST monitoring of the LSST Deep Drilling Fields (ITA-INA-S29)**
+          *Updated: {{ ds.last_updated or 'unknown' }}*
+          +++
+          :bdg-success:`Available`
+      {% else %}
+      .. grid-item-card:: {{ ds.title }}
+          :class-item: ikc-card {{ ds.filter_tokens }}
 
-We propose to use 170 hours/year of VST time to execute a precursorsurvey with VST, to complement and extend in time the LSST dataset on 4 DDF,
-and to combine these observations with all archival data to deliver reduced images, catalogs and lightcurves lasting up to >10 years to the US/Chilean communities.
+          {{ ds.contribution_id }} - {{ ds.country }}
+          ^^^
+          {% for dt in (ds.form_data.data_type or []) %}:bdg-light:`{{ dt }}` {% endfor %}{% for wl in (ds.curated.wavelength_regime or []) %}:bdg-light:`{{ wl }}` {% endfor %}{% for uc in (ds.form_data.uat_category or []) %}:bdg-light:`{{ uc }}` {% endfor %}
 
-Primary Recipient: LSST AGN Science Collaboration
+          {{ ds.curated.summary or 'TBD' }}
 
+          **Primary recipient:** {{ ds.curated.primary_recipient or 'TBD' }}
 
-**Subaru PFS spectroscopic follow-up survey of LSST transients in deep drilling field (JAP-JPG-S10)**
-
-JPG will deliver the data products from the Subaru PFS spectroscopic follow-up survey of LSST transients in drilling fields, to be ingested into Kavli IPMU Lite IDAC.
-
-Primary Recipient: DESC
-
-
-**Subaru PFS filler survey for LSST photo-z training dataset (JAP-JPG-S11)**
-
-The activity offered by JPG would involve the development of a target selection algorithm in close collaboration with Rubin Photo-z Coordination Group and/or DESC,
-the observation and data analysis, the ingestion of the dataset into Kavli IPMU Lite IDAC with NOIRLab CSDC, and finally the scientific application
-of the dataset to improve photo-z accuracy of LSST photometric redshifts.
-
-Primary Recipient: DESC
-
-
-**Contribution to the LSST photo-z calibration with PFS-SSP galaxy evolution dataset (JAP-JPG-S12)**
-
-JPG will deliver the data products of PFS-SSP, based upon approval from the PFS-SSP team, to the LSST community for photo-z calibration and training datasets.
-
-Primary Recipient: DESC
-
-
-**The MOA Archive: a legacy dataset of two decades of photometry across the Galactic Bulge and Magellanic Clouds (NZL-AUK-S2)**
-
-The MOA archive will be ingested into a locally maintained server that will provide image cutouts at the start of the LSST survey and machine calibrated photometry
-12 months after the beginning of the survey, giving high cadence coverage of the Galactic Bulge and Magellanics dating back to 2006.
-
-Primary Recipients: NOIRLab
-
-
-**Supernova Lightcurves and low-resolution spectra for Full-sky Low-redshift Cosmography Complementing LSST (SWE-STK-S4)**
-
-SU will provide online data file access (anticipated to be hosted at NOIRLab) whereby it is possible for LSST users to download the photometry and spectroscopy tables for each ZTF/ZTF-II SN
-(or the entire set at once), as well as the ancillary information about the host galaxy environment. We will provide machine readable files, including standard formats used by lightcurve fitters
-(SALT2, SNooPy) and FITS tables.
-
-Primary Recipient: DESC
-
-
-**LSST-matched MIGHTEE data (UKD-OXF-S7)**
-
-The activity offered by Oxford would involve installation of the MIGHTEE Survey data at the UK DAC, and subsequently,
-joint work with the LSST Science Collaborations in training photo-z (based on HI data and the incorporation of radio continuum and polarisation data) as well as
-user support for the LSST Science Community to facilitate the use of the Survey data.
-
-Primary Recipient: NOIRLab CSDC
-
-
-**Science Software development: Near infrared data fusion (UKD-UKD-S5)**
-
-LSST:UK will provide joint LSST+VISTA near infra-red catalogues produced using the LSST Stack and access to VISTA survey images as a dataset contribution,
-as well as an implementation of the LSST Stack pipeline reconfigured to jointly process LSST pixels with external survey pixels.
-
-Primary Recipient: NOIRLab CSDC
-
-
-**Science Software development: spectroscopic classification of transients and 4MOST spectra (UKD-UKD-S10)**
-
-To provide non-directable software development effort to the LSST DESC for transient spectroscopic follow-up,
-developing software to ensure successful scheduling and observation of transients and their host galaxies by 4MOST,
-and the return the transient types and redshifts to the collaboration (through the Lasair broker, within 24hrs)
-and the final calibrated spectra as contributed data sets on an annual basis.
-
-Primary Recipient: DESC
-
-
-**MeerKAT high-level data products and services for LSST (SZA-SAA-S2)**
-
-South Africa will produce reduced high-level data products (images and catalogs) and services for MeerKAT data,
-as endorsed by the Galaxies Science Collaboration, integrated into the Rubin Science Platform.
-
-Primary Recipients: Galaxies
+          *Updated: {{ ds.last_updated or 'unknown' }}*
+          +++
+          :bdg-muted:`Not yet delivered`
+      {% endif %}
+      {% endfor %}


### PR DESCRIPTION
Replaces the static prose page with a data-driven catalog of the program's 16 dataset contributions, styled after the IDAC dashboard's card layout.

- Add docs/contribution-types/_data/datasets/*.yaml as the per-record source of truth (split into a form_data section owned by a future CSV pull script, and a curated section for hand-edited fields).
- conf.py: load and normalize the YAML records, resolve each record's delivery status (form submission or manual override), compute filter/search tokens, and expose everything to the page via sphinx_jinja.
- contributed-datasets.rst: render a summary table (sortable columns, data type / wavelength / UAT science-case filters, free-text search, available-only toggle, click-through from a table row to its card) plus a sphinx-design card grid with fuller detail per dataset.
- Card and table content share the same filter tokens so both stay in sync from one set of controls.

All 16 entries are currently pre-delivery; the CSV-to-YAML pull script that will populate form_data from real submissions is intentionally not part of this change and will follow once the first contributions are submitted through the in-kind resources form.