### PR TITLE
Add Contributed Software page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,6 +26,11 @@ linkcheck_ignore = [
     # module rejects with CERTIFICATE_VERIFY_FAILED in CI.
     r'https://www\.gtc\.iac\.es/.*',
     r'https://pandora\.lambrate\.inaf\.it/.*',
+    # SER-SAG-S1 (QhX AGN catalogue, linked from both the Datasets and
+    # Software cards) serves an expired SSL certificate -- real,
+    # reachable site that browsers tolerate but Python's ssl module
+    # rejects with CERTIFICATE_VERIFY_FAILED in CI.
+    r'https://ser-sag\.pmf\.kg\.ac\.rs.*',
 ]
 
 

--- a/conf.py
+++ b/conf.py
@@ -550,3 +550,152 @@ jinja_contexts["contributed_opportunities"] = _load_contributed_opportunities()
 jinja_contexts["contributed_opportunities"]["cid_to_slugs"] = (
     jinja_contexts["contributed_telescopes"]["cid_to_slugs"]
 )
+
+
+# ============================================================================
+# Contributed Software page data loading
+#
+# Each software-contribution record lives as a YAML file in
+# docs/contribution-types/_data/software/<contribution-id>.yaml, split into
+# a `form_data` section (owned by scripts/sync_software_contributions.py;
+# safe to overwrite) and a `curated` section (hand-edited only; the sync
+# script never touches it) -- same split as the Contributed Datasets page.
+# General Pool contributions are not part of this dataset at all (they have
+# their own page); every record here is Directable or Non-directable.
+# ============================================================================
+
+def _software_status(record):
+    curated = record.get("curated") or {}
+    if curated.get("status_override"):
+        return curated["status_override"]
+    return "delivered" if (record.get("form_data") or {}).get("submitted") else "pending"
+
+
+def _resolve_related_titles(related_ids, *page_lookups):
+    """page_lookups is a sequence of (page_html_filename, {contribution_id: title})
+    pairs, checked in order, so the returned dicts know which page to link to."""
+    resolved = []
+    for rid in related_ids or []:
+        title = None
+        page_url = None
+        for page_html, lookup in page_lookups:
+            if rid in lookup:
+                title = lookup[rid]
+                page_url = page_html
+                break
+        resolved.append({
+            "contribution_id": rid,
+            "title": title or rid,
+            "slug": _slugify(rid),
+            "page_url": page_url,
+        })
+    return resolved
+
+
+def _load_contributed_software():
+    data_dir = (
+        Path(__file__).parent
+        / "docs"
+        / "contribution-types"
+        / "_data"
+        / "software"
+    )
+    dataset_titles = _collect_cross_page_titles("datasets")
+    telescope_titles = _collect_cross_page_titles("telescopes")
+
+    records = []
+    all_categories = set()
+    all_uat = set()
+    all_recipients = set()
+
+    for path in sorted(data_dir.glob("*.yaml")):
+        with path.open(encoding="utf-8") as f:
+            record = yaml.safe_load(f) or {}
+        record = _normalize_strings(record)
+        form_data = record.setdefault("form_data", {}) or {}
+        curated = record.setdefault("curated", {}) or {}
+
+        status = _software_status(record)
+        record["status"] = status
+
+        category = form_data.get("category") or "Unknown"
+        # Real UAT answers from a team's own form submission take
+        # precedence over the sync script's keyword-guessed curated tags.
+        uat_keywords = form_data.get("uat_category") or curated.get("uat_keywords") or []
+        primary_recipient = form_data.get("primary_recipient_group") or ""
+
+        all_categories.add(category)
+        all_uat.update(uat_keywords)
+        if primary_recipient:
+            all_recipients.add(primary_recipient)
+
+        cid_slug = _slugify(record.get("contribution_id", ""))
+        record["cid_slug"] = cid_slug
+        record["last_updated"] = _last_updated(path)
+        record["uat_keywords"] = uat_keywords
+        record["related"] = _resolve_related_titles(
+            curated.get("related_contribution_ids"),
+            ("contributed-datasets.html", dataset_titles),
+            ("contributed-telescope.html", telescope_titles),
+        )
+
+        tokens = [
+            f"status-{_slugify(status)}",
+            f"cid-{cid_slug}",
+            f"cat-{_slugify(category)}",
+        ]
+        if primary_recipient:
+            tokens.append(f"recipient-{_slugify(primary_recipient)}")
+        tokens += [f"uat-{_slugify(v)}" for v in uat_keywords]
+        record["filter_tokens"] = " ".join(tokens)
+
+        search_parts = [
+            record.get("title", ""),
+            form_data.get("activity_description", "") or "",
+            primary_recipient,
+            *(form_data.get("additional_recipient_groups") or []),
+            *uat_keywords,
+        ]
+        record["search_text"] = " ".join(search_parts).lower()
+
+        records.append(record)
+
+    records.sort(key=lambda r: r.get("last_updated") or "", reverse=True)
+    search_index = {r["cid_slug"]: r["search_text"] for r in records}
+    return {
+        "software": records,
+        "all_categories": sorted(all_categories),
+        "all_uat": sorted(all_uat),
+        "all_recipients": sorted(all_recipients),
+        "slugify": _slugify,
+        "search_index_json": json.dumps(search_index),
+    }
+
+
+def _collect_cross_page_titles(subdir_name):
+    """contribution_id -> title/facility lookup for a sibling _data folder,
+    used to label the Contributed Software page's "Also see" cross-links
+    without needing that page's full loader context. contribution_id may be
+    a scalar or, on the Telescopes page, a list shared by sibling records."""
+    data_dir = (
+        Path(__file__).parent
+        / "docs"
+        / "contribution-types"
+        / "_data"
+        / subdir_name
+    )
+    out = {}
+    if not data_dir.exists():
+        return out
+    for path in sorted(data_dir.glob("*.yaml")):
+        with path.open(encoding="utf-8") as f:
+            record = yaml.safe_load(f) or {}
+        cid = record.get("contribution_id")
+        cids = cid if isinstance(cid, list) else [cid]
+        for c in cids:
+            if c:
+                out[c] = record.get("title") or record.get("facility") or c
+    return out
+
+
+jinja_contexts["contributed_software"] = _load_contributed_software()

--- a/docs/contribution-types/_data/datasets/SER-SAG-S1.yaml
+++ b/docs/contribution-types/_data/datasets/SER-SAG-S1.yaml
@@ -1,0 +1,70 @@
+contribution_id: SER-SAG-S1
+title: Science Pipeline Development for analysis of variability of celestial sources in the
+  LSST AGN and TVS Science Collaboration (associated dataset)
+country: Serbia
+institute: SAGNT
+form_data:
+  submitted: true
+  data_type:
+  - Value-Added Catalogs
+  data_volume: The current QhX Hub is based on known quasars in LSST DP1. Of approximately
+    1,500 cross-matched quasars, 428 met the sampling criteria and form the analysed sample.
+    For these sources the Hub stores statistical results (object-level and per-band tables,
+    including light-curve features and coherence/vetting metrics) together with per-object
+    images and interactive plots. The current total data volume is of order a few hundred
+    megabytes, dominated by the image and interactive-plot products; it will scale with successive
+    LSST Data Releases.
+  data_schema_link: https://zenodo.org/records/18248330
+  hosting_location: It resides on data cloud machine at University of Kragujevac that is obtained
+    through TVS SC Kickstarter grant https://faculty.washington.edu/ivezic/lsst/LOI2022Plitvice/Simic_Regional_Storage_Support_for_LSST_Related_Science.pdf
+  access_url: https://ser-sag.pmf.kg.ac.rs:8081/agn_catalogue.php
+  access_mechanisms:
+  - TAP / Virtual Observatory Service
+  - API
+  - Web Portal / Interface
+  authentication: Rubin Data Rights verification (RSP authentication)
+  generation_methods: 'Generated with the QhX pipeline delivered under this contribution (ID
+    SER-SAG-S1): wavelet (WWZ) time–frequency analysis + 2D period–period cross-correlation
+    with statistical vetting (significance, period-error bounds, IoU). Input DP1 light curves
+    selected by cross-matching DP1 sources (via LSDB) with external AGN catalogues (DESI,
+    Quaia, MilliQuas, ZTF/QZO); products served through the QhX Hub. Software: https://github.com/LSST-SER-SAG-S1/QhX1
+    (Kovačević et al. 2026, JOSS, doi:10.21105/joss.08163), Catalogue: Kovačević et al. 2026
+    (ApJS, accepted). Docs: Cerovic et al 2026 doi:10.5281/zenodo.17914817.'
+  validation_limitations: 'QA in Kovačević et al. 2026 (ApJS, accepted): permutation significance,
+    cross-band IoU consistency, sinusoidal vetting (SN larger 1.5, phase-lag larger than 0.10),
+    FDR control (Benjamini–Hochberg, none rejected); reliability via Dawid–Skene (0.023) and
+    alias-floor (0.975) purity. Limitations: prototype DP1 catalogue; 7-week baseline, possible
+    to infer day-scale only; strong diurnal aliasing (0.5, 1, 2 d); sample g,r,i,z larger
+    than 50 epochs (428 of1,456; u/y excluded); conservative (1 strong + 15 medium of 230);
+    asymmetric baseline-limited period errors.'
+  tutorials_docs: Catalogue functioQhX Hub (https://ser-sag.pmf.kg.ac.rs:8081/agn_catalogue.php,
+    doi:10.5281/zenodo.17914817),
+  support_channel: agncatalogue.sersag@gmail.com.
+  citation: 'Citation. Users of the QhX AGN variability catalogue / QhX Hub should cite the
+    catalogue paper (Kovačević et al. 2026, ApJSS ) and its technical documentation (Stanković
+    Cerović et al. 2025, Zenodo, doi:10.5281/zenodo.17914817). Acknowledgement. In addition
+    to the citations above, please include: "This work makes use of data/software products
+    from the QhX contribution, developed as a contribution to the Rubin community through
+    the Rubin In-Kind program, with contribution ID SER-SAG-S1." License. The catalogue data
+    products are open-access; access to the full catalogue via the QhX Hub is granted to Rubin
+    Data Rights Holders on request (ORCID authentication), consistent with Rubin data-rights
+    policy.'
+  maintenance_plan: Discrete future Data Releases (e.g. DR2)
+  maintenance_notes: repository/release upkeep, bug fixing, dependency updates, and documentation/tutorial
+    maintenance, continued application to new Rubin data releases; user support and occasional
+    training; and dissemination through publications, presentations, and QhX Hub citizen-science
+    activities. Estimated effort ~0.05–0.10 FTE across the team.
+  final_report: The final/completion summary was included in the FY26 Q3 Quarterly Update
+    (June 2026), which reported completion of the QhX software and QhX Hub development (along
+    QNPy/Latte) and the transition to maintenance. It was also reflected in the FY25 Annual
+    Evaluation, which stated the contribution had delivered the fully operable pipeline and
+    entered the maintenance and deployment phase.
+curated:
+  primary_recipient: LSST AGN Science Collaboration
+  target_audience: Specific Science Collaboration (e.g., DESC, TVS, SMWLV)
+  summary: null
+  wavelength_regime: []
+  status_override: null
+  related_contribution_ids:
+  - SER-SAG-S1
+  needs_review: true

--- a/docs/contribution-types/_data/datasets/SZA-SAA-S2.yaml
+++ b/docs/contribution-types/_data/datasets/SZA-SAA-S2.yaml
@@ -37,3 +37,4 @@ curated:
     Science Collaboration, integrated into the Rubin Science Platform.
   wavelength_regime: [Radio]
   status_override: null
+  related_contribution_ids: [SZA-SAA-S2]  # cross-link to the matching Contributed Software page card

--- a/docs/contribution-types/_data/datasets/UKD-UKD-S10.yaml
+++ b/docs/contribution-types/_data/datasets/UKD-UKD-S10.yaml
@@ -41,3 +41,4 @@ curated:
     an annual basis.
   wavelength_regime: [Optical]
   status_override: null
+  related_contribution_ids: [UKD-UKD-S10]  # cross-link to the matching Contributed Software page card

--- a/docs/contribution-types/_data/software/AUS-AAL-S2.yaml
+++ b/docs/contribution-types/_data/software/AUS-AAL-S2.yaml
@@ -1,0 +1,56 @@
+contribution_id: AUS-AAL-S2
+title: Dedicated Software Development Effort
+country: Australia
+institute: AAL
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'ADACS-Maquarie will contribute directable software development effort
+    in the general area of Rubin Low Surface Brightness science analysis, including establishing
+    the optimal sky subtraction method for retaining this light. As sky estimation affects
+    source detection, de-blending, and photometry, and requires access to all the pixels,
+    it is best done early in the processing steps rather than as level-3 post-processing.
+    ADACS-Maquarie staff will work with the Galaxies SC and Low Surface Brightness WG to define
+    the optimal method, as an integral part of the collaboration taking input from the rest
+    of the WG and SC, and supporting the integration of that code into the Stack taking input
+    from the Rubin DM team and reporting regularly on progress.We have developed this contribution
+    in coordination with the Galaxies Science Collaboration which supports our proposed approach.We
+    anticipate needing modest amounts of local computing to support this work and focus on
+    using Rubin-provided user computing resources as they become available to ensure the code
+    functions at the needed scale. The aforementioned local computing resources are already
+    available at ADACS-Maquarie and UNSW (where Prof Brough is located), and we will work
+    to secure additional local resources if needed. The primary risk associated with this
+    work is in gaining the needed expertise in the Rubin tools and data products: to mitigate
+    this, the ADACS-Maquarie staff will engage early with the Rubin DM team, and would be
+    expected to work through the “stack club” tutorial notebooks as well as to be active participants
+    in the current Low Surface Brightness Working Group Challenges, within the context of
+    the Galaxies SC. Should travel become possible, travel to meet with the Rubin DM team
+    will be supported.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/BRA-LIN-S3.yaml
+++ b/docs/contribution-types/_data/software/BRA-LIN-S3.yaml
@@ -1,0 +1,45 @@
+contribution_id: BRA-LIN-S3
+title: Contributions to Science Pipeline Development in the LSST-DESC TJP Working Group
+country: Brazil
+institute: LIneA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: LIneA will contribute with directable software development effort
+    in the general area of cosmological calculations (Theory, Covariances, and Joint Probes).
+    The direct software development efforts include the development and validation of CCL,
+    firecrown, and development of TJP Covariance pipeline (TJPCov) for multiprobe analysis.
+    Since development will take place inside DESC projects, most of it will be done locally
+    and tested inside Rubin-provided computer resources (NERSC). When it comes to this proposal,
+    the main challenge is acquiring the needed expertise in the LSST-DESC. In order to mitigate
+    this risk, the members are engaged with the Pipeline Scientist group and interacting within
+    the DESC TJP working group. If necessary LIneA also provides computing infrastructure
+    that can be used to run and test the developed codes.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/BRA-LIN-S4.yaml
+++ b/docs/contribution-types/_data/software/BRA-LIN-S4.yaml
@@ -1,0 +1,91 @@
+contribution_id: BRA-LIN-S4
+title: Infrastructure and data sets to support photo-z generation
+country: Brazil
+institute: LIneA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Photo-z Coordination Group
+  additional_recipient_groups:
+  - Rubin Algorithms & Pipelines Team
+  - LSST Galaxies Science Collaboration
+  activity_description: 'LIneA will contribute directable software development effort in the
+    general area of data preparation for science analysis in LSST. The contribution consists
+    of adding value to the LSST Data Release Objects catalog providing standardized training
+    and validation sets, photometric redshifts and galaxy properties estimates. LIneA staff
+    is already participating in the Photo-z Virtual Forum and will work with LSST Project
+    to define needed software development tasks and deliverable data products, carry out those
+    tasks as an integral part of the contribution, take input from the rest of the Science
+    Community/users, regularly reporting the progress.The planned activities include: (i)
+    Maintain a spectroscopic redshifts (spec-z) repository with data from public releases
+    of spec-z surveys, monitor the literature to keep the spec-z repository up to date, produce
+    standardized training and validation samples regularly before each DR, work together with
+    the Project to make these data products available to the community via RSP. (ii) Develop
+    a photo-z server to support the ''Photo-z Validation Cooperative'' including the implementation
+    of a photo-z validation pipeline and administrative tools. Write documentation and provide
+    office hours to support authors for integrating new photo-z codes into the pipeline. Work
+    collaboratively with the Project to make this service available to the community on RSP.
+    (iii) Support to the ''Photo-z Validation Cooperative'' in organizing the results from
+    different groups and making it available in a single document. (iv) Run the photo-z(s)
+    algorithm(s) chosen by the community, produce photo-z (single estimates and posterior
+    PDFs) and galaxy properties catalogs for all objects in the Object catalog and export
+    the results to the RSP as federated datasets before each DR. The proposed activities include
+    the upgrade of photo-z related pipelines of the DES Science Portal to scale to the data
+    volume of LSST (the photo-z related input and output columns) and improve some of the
+    short-comings identified in the earlier DES version. To this end new software solutions
+    are already being investigated by the LIneA IT team to improve the orchestration code
+    to make it more flexible and portable, and the handling of the input data taking advantage
+    of the new Lustre storage system, which is being installed and tested by Adean. In recent
+    preliminary tests done by Singulani using Parsl (http://parsl-project.org, Babuji et al.,
+    2019) to orchestrate a workflow for running the template-fitting code LePHARE (Arnouts
+    et al. 1999, Ilbert et al. 2006), LIneA achieved a benchmark of 0.2 milliseconds per object,
+    which can be interpreted as an upper limit estimate considering that machine learning
+    codes are, on average, faster than the template-fitting ones. That benchmark includes
+    the whole process of transforming data from parquet files into ascii inputs required by
+    LePHARE, running all steps of the photo-z code, and saving the outputs also in parquet
+    format. Such activities are part of the ongoing revision of the codebase which is being
+    carried out to improve performance and include in-line documentation. In parallel, a considerable
+    effort is being carried out to document the code and write technical notes describing
+    the products to the users. LIneA agrees to share the software created to serve LSST as
+    open-source in any code sharing platform adopted by the recipient groups. The precursor
+    DES Science Portal codes are already in public domain in GIT (http://git.linea.gov.br),
+    except for the private scientific codes which are wrapped into the Portal and used as
+    ''blackboxes''. All LIneA''s public codes are in the process of migration to LIneA''s
+    organization on Github (https://github.com/linea-it). LIneA anticipates that a considerable
+    amount of local computing will be required to support this work, with seasonal peaks of
+    usage before each data release. LIneA will provide local computing resources and storage
+    space for the products which will be federated with other DACs and the IDAC network via
+    the Brazilian Lite-IDAC, pending its final approval. The processing will be carried out
+    using the computer clusters already available in LIneA''s datacenter. The remaining resources
+    are dependent on the approval and subsequent implementation of the Brazilian IDAC, so
+    the risk associated with this work is coupled with the IDAC project''s success.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Galaxy clusters
+  - Machine learning
+  - Photometric redshift
+  - Spectroscopy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CAN-CAN-S3.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S3.yaml
@@ -1,0 +1,54 @@
+contribution_id: CAN-CAN-S3
+title: Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: Canada
+institute: LSST:Canada
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-Z Coordination Group
+  activity_description: The Canadian LSST consortium will contribute directable software development
+    effort in the general area of LSST DESC science analysis, which may include, but is not
+    limited to:the development of Alert/broker support/difference image analysis support;the
+    development of spectroscopic follow-up targeting software;the integration of the supernova
+    pipeline and adaptation to the real science verification data;contributions to weak lensing
+    image simulations;developing cross-correlation pipelines with wide-field surveys such
+    as Euclid for galaxy shapes and photo-z estimation, should a collaborative agreement be
+    reached between Euclid and Rubin; support of the DESC computational infrastructure pipeline.The
+    dedicated staff will work with the DESC leadership to define needed software development
+    tasks, and will be embedded in the DESC. They will carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the code.
+    In addition to DESC resources, the staff will use the CLASP computing resources if needed
+    to complete these tasks.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  - Photometric redshift
+  - Spectroscopy
+  - Supernovae
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CAN-CAN-S4.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S4.yaml
@@ -1,0 +1,48 @@
+contribution_id: CAN-CAN-S4
+title: Science Pipeline Development in the LSST Transient and Variable Star Science Collaboration
+country: Canada
+institute: LSST:Canada
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The Canadian LSST consortium will contribute directable software development
+    effort through CLASP Infrastructure Fellows (CIF) who will work in the general area of
+    LSST TVS science analysis, including but not limited to the development of Alert/broker
+    support/difference image analysis support, and the development of spectroscopic follow-up
+    targeting software.The dedicated staff will work with the TVS leadership to define needed
+    software development tasks, and will be embedded in the TVS. They will carry out those
+    tasks as an integral part of the collaboration, reporting regularly on progress, taking
+    input from the rest of the collaboration, and supporting the collaboration’s members in
+    the use of the code. The staff will use the CLASP computing resources if needed to complete
+    these tasks, no additional computing support will be required from TVS resources.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Spectroscopy
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CAN-CAN-S5.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S5.yaml
@@ -1,0 +1,48 @@
+contribution_id: CAN-CAN-S5
+title: Science Pipeline Development in the LSST Galaxies Science Collaboration
+country: Canada
+institute: LSST:Canada
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The Canadian LSST consortium will contribute directable software development
+    effort in the general area of LSST Galaxies science analysis, including but not limited
+    to building pipelines for galaxy classification and morphology studies and developing
+    spectroscopic training pipelines of photometric redshift estimates, however the CIF will
+    work on the specific tasks needed by the Galaxies collaboration as a directable contribution.The
+    dedicated CIF will work with the leadership of the Galaxies collaboration to define needed
+    software development tasks, and will be embedded in the LSST Galaxies collaboration. They
+    will carry out those tasks as an integral part of the collaboration, reporting regularly
+    on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code. The staff will use the CLASP computing resources if needed
+    to complete these tasks.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  - Photometric redshift
+  - Spectroscopy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CAN-CAN-S6.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S6.yaml
@@ -1,0 +1,63 @@
+contribution_id: CAN-CAN-S6
+title: Science Pipeline Development in the LSST AGN Science Collaboration
+country: Canada
+institute: LSST:Canada
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The Canadian LSST consortium will contribute directable software development
+    effort for LSST AGN science analysis, in two general areas:Developing image stacking,
+    image differencing, and variable-source detection software components of the LSST Software
+    Stack that are optimized for detecting variability on longer timescales of weeks to months.
+    This software will be distinct from LSST’s transient detection pipeline, which is optimized
+    for detection of transients and variability on shorter timescales of days. This distinction
+    is crucial because AGN characteristically exhibit observed-frame optical continuum variability
+    on longer timescales than transients. For example, slow stochastic variability on timescales
+    of weeks from a faint AGN in a spatially-extended dwarf galaxy would be missed by the
+    standard transient detection pipeline in the LSST Software Stack, and its detection would
+    require stacking and subtraction of images taken over several weeks. Developing an AGN
+    alerts pipeline for detection and rapid notification of peculiar AGN variability activity,
+    such as outbursting or fading ‘changing-look AGN’. These objects puzzlingly exhibit a
+    wide variety of variability properties that do not seem to follow the well-known red-noise
+    variability of most AGN. The origin of these peculiar variability phenomena in both emission
+    and absorption and their relation to other types of nuclear variability (such as Tidal
+    Disruption Event flares) are unknown. The AGN alerts pipeline would use light curves from
+    the image differencing software described above to detect any peculiar variability in
+    real-time, based on modeling the temporal and spectral properties of the non-simultaneous
+    multi-band light curves that are updated as the data are obtained.This proposal has been
+    endorsed by the LSST AGN Science Collaboration. The dedicated staff will work with the
+    leadership of the AGN Science Collaboration to define needed software development tasks,
+    and will be embedded in the AGN collaboration. They will carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the code.
+    The staff will use the CLASP computing resources if needed to complete these tasks.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CAN-CAN-S7.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S7.yaml
@@ -1,0 +1,50 @@
+contribution_id: CAN-CAN-S7
+title: Science Pipeline Development in the LSST Solar System Science Collaboration
+country: Canada
+institute: LSST:Canada
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Solar System Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The Canadian LSST consortium will contribute directable software development
+    effort in the general area of LSST Solar System science analysis, to meet some of the
+    requirements laid out in the SSSC software roadmap[2]. Possible contributions that match
+    well with the anticipated expertise of the PDF include:Developing hooks between the Canadian
+    LSST public archive and the CADC’s Solar System Object Image Search archival tools to
+    enable pre-covery of newly discovered moving bodies, for use by the SSSC, as encouraged
+    through the CEC’s feedback of the CLASP LOI.An ephemeris driven cutout service.A forced
+    photometry package with techniques appropriate for moving objects like those implemented
+    in Trailed Imaging in Python[3]The dedicated staff will work with the SSSC leadership
+    and the SSSC’s Community Software and Infrastructure Development Working Group, to define
+    needed software development tasks, and will be embedded in the SSSC. They will carry out
+    those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, and supporting the collaboration’s members
+    in the use of the code. The staff will use the CLASP computing resources if needed to
+    complete these tasks.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Solar system astronomy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/CRO-RBI-S1.yaml
+++ b/docs/contribution-types/_data/software/CRO-RBI-S1.yaml
@@ -1,0 +1,64 @@
+contribution_id: CRO-RBI-S1
+title: Science Analysis Infrastructure Effort
+country: Croatia
+institute: RBI
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups:
+  - Rubin International Program Coordinator (Software Development)
+  activity_description: 'Software development effort would be provided by the two of the institutions
+    participating in CPG: RBI and HO. In both cases a postdoctoral researcher would be hired,
+    in order to provide directable software development effort. Whether the contribution will
+    be in the terms of general pooled effort or directable software effort embedded in the
+    TVS SC will depend on the outcome of the selection procedure. In either case the selected
+    candidates will provide no less than 0.5 FTE/year. This approach is motivated by a risk
+    that we have identified and its mitigation strategy: we do not expect that many software
+    engineers with PhDs (ideally working full time on LSST software development) or astronomy
+    postdocs (working part time on software development) will be applying to the positions
+    that we will be advertising. By advertising a more flexible scheme, we hope to attract
+    a larger talent pool and ultimately select better candidates. We have already requested
+    TVS SC Justice, Equity, Diversity, and Inclusion (JEDI) group to act as advisors in order
+    to help us select the best candidates and ensure fairness throughout the hiring procedure.
+    We would like to extend the same invitation to any relevant group or committee at the
+    LSST-wide level.As the efforts are directable, we would work with the relevant LSST groups
+    to define the exact kind of the needed software development tasks, carry out those tasks,
+    report regularly on the progress, take input from the rest of the collaboration and support
+    collaboration members in the use of the code. Presently it is difficult to assess the
+    local hardware requirements, but we do note that significant computing resources are offered
+    as the second part of our contributions (CRO-RBI-2) and that it would be logical to make
+    use of these resources. TVS SC endorsement has been received for these contributions.In
+    case of the general pooled software development effort to either the LSST science collaborations
+    or Rubin Observatory teams, CPG staff will work with the Rubin International Program Coordinators
+    (and through them, the CEC) to identify a suitable recipient group, work with that group
+    to define needed software development tasks, and then carry out those tasks as an integral
+    part of the group, reporting regularly on progress, taking input from the rest of the
+    group, and supporting the group’s members in the use of the code.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ESP-BCM-S1.yaml
+++ b/docs/contribution-types/_data/software/ESP-BCM-S1.yaml
@@ -1,0 +1,52 @@
+contribution_id: ESP-BCM-S1
+title: Contribution of Directable Software Development Effort to DESC Computing Infrastructure
+  Operations team
+country: Spain
+institute: BCN_MAD
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: BCN-MAD will contribute directable effort to the Dark Energy Science
+    Collaboration in the form of focused planning, development and deployment of test cases
+    and procedures for ongoing and planned Data Challenges of DESC, adapting to, reinforcing
+    or repurposing current efforts in this area from scattered groups and researchers. Long
+    term planning will start in October 2020 so that these tests can eventually be reworked
+    into tests for Data Management products within the context of DESC, as commissioning data
+    becomes available, even feeding back into this process where applicable. The fact that
+    the Contribution Lead is applying also for some effort in the Project’s commissioning
+    team can be of great value for both contributions and synergistic.The proposed contribution
+    lead would adapt to any other tasks within the context of Computing Infrastructure for
+    DESC. The detailed work plan will be developed in consultation with the relevant members
+    of the DESC leadership. Regular reporting would be made as planned by DESC. The Contribution’s
+    Lead group at CIEMAT has direct access to moderate computing resources, which are considered
+    sufficient, as in principle most of the development and execution will be done in the
+    NERSC environment. The Contribution Lead has already access and experience working with
+    the DESC environment at NERSC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ESP-BCM-S3.yaml
+++ b/docs/contribution-types/_data/software/ESP-BCM-S3.yaml
@@ -1,0 +1,52 @@
+contribution_id: ESP-BCM-S3
+title: Contribution of Directable Software Development Effort to DESC Large Scale Structure
+  and/or photo-z WG
+country: Spain
+institute: BCN_MAD
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: BCN-MAD will contribute directable software development effort to
+    the Dark Energy Science Collaboration in the general area of Large Scale Structure and
+    photometric redshifts. BCN-MAD will work with the DESC SC to define the needed software
+    development tasks, and then carry out those tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration members in the use of the code. The detailed work plan will
+    be developed in consultation with the relevant members of the DESC leadership. BCN-MAD
+    anticipates a modest amount of computing for development, especially given that full deployment
+    will require the use of official Rubin computing resources and NERSC. In any case, the
+    Group counts with substantial local resources as well which should be more than enough
+    for the scale of these focused developments, as well as potentially direct access to one
+    of LSST’s Lite IDACs. The BCN-MAD team has engaged the Rubin data environment already
+    through one of its team members (see Contribution 1), which would transfer the needed
+    knowledge to members of this new team locally.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-ARI-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-ARI-S1.yaml
@@ -1,0 +1,52 @@
+contribution_id: GER-ARI-S1
+title: Target and Observations Management (TOM) system Development in the LSST TVS Science
+  Collaboration
+country: Germany
+institute: ARI_ZAH
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'ARI will contribute directable software development effort in the
+    general area of LSST TVS science analysis focused primarily in the development of a Target
+    and Observation Management (TOM) system to serve the specific science goals of TVS. ARI
+    staff will work with the TVS SC to define needed software development tasks, and then
+    carry out those tasks as an integral part of the collaboration, reporting regularly on
+    progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code. We anticipate needing modest amounts of cloud computing
+    to support this work, and will focus on using Rubin-provided user computing resources
+    as they become available to ensure the code functions at the needed scale. The aforementioned
+    cloud computing resources will be secured by ARI on a well established commercial cloud
+    server, such as Amazon AWS, and we will work with TVS to arrange additional resources
+    if needed. The primary risk associated with this work is in gaining the needed expertise
+    in the Rubin tools and data products: to mitigate this, the ARI staff will engage early
+    with any Rubin tutorials provided, and look to be active participants in events associated
+    with the Rubin “Data Previews”, all within the context of the TVS SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-CCL-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-CCL-S1.yaml
@@ -1,0 +1,68 @@
+contribution_id: GER-CCL-S1
+title: Science Pipeline Development in the Dark Energy Science Collaboration
+country: Germany
+institute: GCCL
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The GCCL will contribute directable software development efforts in
+    the general area of Dark Energy Consortium science analysis, working with DESC to define
+    needed software development tasks. We will carry out those tasks as an integral part of
+    the collaboration, reporting regularly on progress, taking input from the rest of the
+    collaboration, and supporting the collaboration’s members in the use of the code. Our
+    preference is for the GCCL directable effort to be mainly embedded within the DESC Photometric
+    Redshift working group, for example making a significant contribution to photometric redshift
+    calibration and quantifying and mitigating spectroscopic incompleteness. Given the wide
+    range of expertise at the GCCL, the group could also, however, contribute to the LSST
+    optical cluster detection algorithm and the quantification of the resulting selection
+    function, both key deliverables for the Cluster working group, in addition to contributing
+    to a wide range of different deliverables required for the weak lensing working group
+    and the theory-joint probes working group. We will work with DESC leadership to narrow
+    down this wide range of activities into a defined list of tasks based on their needs and
+    the skill profile of the postdocs and/or software engineers that will be recruited for
+    the start of FY22. With mutual agreement, the DESC may request a change of direction in
+    the future if the goals and resources available to the DESC require it. We have significant
+    funding to support the local computing that will be required to support this work. Based
+    on the requirements from the final defined list of tasks, a procurement exercise will
+    be undertaken to ensure that we have appropriate computing resources, in addition to our
+    already existing compute cluster. We will also use NERSC resources to ensure the code
+    we contribute runs well at NERSC such that DESC members outside the GCCL can easily collaborate
+    with the GCCL team.The primary risk associated with this work is in the recruitment and
+    retention of staff with relevant expertise and skills. This risk will be mitigated somewhat
+    by offering each new GCCL member hired for this role, the opportunity to use up to 50%
+    of their time to pursue their own research interests, over a full three-year position.
+    In addition we have a significant number of existing experienced GCCL fellows with strong
+    interests in DESC, whose efforts could be diverted to directable software development
+    effort, if the task is already in line with their scientific interests.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  - Photometric redshift
+  - Spectroscopy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-CCL-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-CCL-S2.yaml
@@ -1,0 +1,59 @@
+contribution_id: GER-CCL-S2
+title: Science Pipeline Development in the Dark Energy Science Collaboration
+country: Germany
+institute: GCCL
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'As part of the GCCL contribution, Robert Reischke and Andrina Nicola
+    will contribute directable software development efforts to LSST DESC. After consultation
+    with the WLSS, MCP and CL WGs in DESC as well as the analysis coordination team, we have
+    settled on the following proposed development effort: The primary goal of this contribution
+    is to implement the covariance tools needed to perform cluster cosmology analyses using
+    TJPCov and CCL. We will implement theoretical predictions for cluster overdensity cross-correlations
+    into CCL. In addition, we will implement cluster cross 2pt-function covariances into TJPCov
+    and validate them using independent implementations. We will do this both for optical
+    clusters as well as tSZ-selected clusters to allow for joint analyses with CMB surveys.
+    In particular, we will coordinate development of the analysis pipeline with the Simons
+    Observatory to facilitate future combined analyses (examples are: consistent theory predictions
+    and likelihoods/samplers). In a first step, we will focus on Fourier space. If needed,
+    we could also extend to real space correlations.In a second part of this in-kind contribution,
+    we will support the development of the augur forecasting tool and help with implementing
+    cluster cosmology forecasts. However, with mutual agreement, the DESC may request a change
+    of direction in the future if the goals and resources available to the DESC require it.We
+    have secured funding to cover the position of Robert Reischke, who has joined the AIfA
+    in October 2023. He will be able to dedicate 0.5 FTE for 2 years starting at any time
+    convenient for Rubin and DESC. In addition, we have access to local computing resources
+    to support this work. We will also work on NERSC to ensure that the developed tools run
+    there as well and to facilitate collaboration with other DESC researchers. Given that
+    a person with very relevant expertise has already been hired, the risk associated with
+    this contribution is minor.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-LMU-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S1.yaml
@@ -1,0 +1,59 @@
+contribution_id: GER-LMU-S1
+title: Calibration pipeline development for Weak Gravitational Lensing analyses in the LSST
+  Dark Energy Science Collaboration [near-term directable software development]
+country: Germany
+institute: LMU_Munich
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: 'Prof. Dr. Gruen’s team will contribute directable software development
+    effort in the general area of LSST Dark Energy science weak lensing analysis. Depending
+    on the candidate hired with the transition of the group to LMU, an on coordination with
+    the relevant DESC working groups, this could e.g. be in the area of image simulations
+    for weak lensing shear and photometric redshift calibration or other pipelines for photometric
+    redshift calibration purposes, or the correction of other weak lensing related systematics
+    in DESC observables. Team members will work with the DESC, particularly the WL, PZ, and
+    BL working groups, to define needed software development tasks. They will then carry out
+    those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, supporting the collaboration’s members
+    in the use of the code, and running the code at scale to produce the required calibrations
+    for DESC weak lensing science. We anticipate needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at Munich, and we will work to secure
+    additional local resources if needed. The primary risk associated with this work is in
+    gaining the needed expertise in the Rubin tools and data products and connect and extend
+    them for the needs of weak lensing calibration: to mitigate this, staff will engage early
+    with DESC working groups, the DESC Spokespersons and Analysis Coordinators, any tutorials
+    and codes provided, and look to be active participants in the WL, PZ and BL working groups.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-LMU-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S2.yaml
@@ -1,0 +1,65 @@
+contribution_id: GER-LMU-S2
+title: Galaxy Cluster Analysis Infrastructure [near-term directable software development,
+  developed in consultation with LSST-DESC]
+country: Germany
+institute: LMU_Munich
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: We will contribute directable software development effort to DESC
+    in the general area of enabling cluster cosmology analyses. Under the direction of the
+    relevant members of the DESC leadership, and depending on the candidates hired for these
+    tasks, we propose to contribute to i) the development and testing of the multi-observable
+    cluster cosmology pipeline, ii) the simulation-based calibration of the relationship between
+    halo mass and the weak-lensing shear signal, accounting for all relevant sources of systematic
+    uncertainties, iii) the tools required for the construction of multi-wavelength cluster
+    catalogs, and iv) the development and implementation of emulators, with particular focus
+    on the cosmological emulators as defined in the DESC science roadmap. In consultation
+    with the relevant members of the DESC leadership--- presumably including the coordinators
+    of the Clusters, Weak Lensing, and Cosmology Simulations working groups--- we will work
+    to define needed software development tasks, and then carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, supporting the collaboration members in the use of the code, and
+    running the codes at scale to produce the required data products and results.We expect
+    the computational needs associated with our contributions to be provided at NERSC, DESC’s
+    primary computing center, but to also draw upon local resources owned by our group and
+    major computing resources in the Munich area to which we have guaranteed access (e.g.,
+    C2PAP at LRZ). This range of computing resources will support efficient development and
+    testing while allowing more extensive testing to ensure the codes function at the needed
+    scale.The primary risk associated with this work is in gaining the needed expertise in
+    the Rubin and DESC tools and data products and in understanding how best to apply them
+    in the context of cluster cosmology. To mitigate this, our group members will engage early
+    with the appropriate DESC working groups, analysis coordinators, and any available tutorial
+    and instruction resources. We wish to be active participants in the clusters, weak lensing,
+    and computing working groups and to establish fruitful scientific and technical exchange.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-LMU-S3.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S3.yaml
@@ -1,0 +1,63 @@
+contribution_id: GER-LMU-S3
+title: Cluster Line of Sight Simulation Software (near-term directable software development)
+country: Germany
+institute: LMU_Munich
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: Stella Seitz’s group will contribute directible software development
+    which aims to support LSST cluster weak lensing analyses and derived cosmological constraints.
+    Since we have expertise in generating realistic cluster lines of sights and rendering
+    the according photometric-morphological catalogues into image simulations we find it likely
+    that our effort is directed by the Survey Simulations and the Clusters WGs. To specify
+    our contribution, we will consult the relevant members of DESC leadership regarding the
+    WG priorities and we will then develop a work plan via mutual agreement. Since cluster
+    weak lensing analyses are interconnected to the BL, the PZ, the WL, the SSim, and TJP
+    WGs we expect that our team members will interact with all the aforementioned WGs to optimally
+    fulfill the software development tasks.In case our group is directed in a way that involves
+    producing image simulations, we would like to ensure that they are processible with Rubin's
+    LSST Science Pipelines. For that reason we would like to (where appropriate and beneficial
+    to the success of the work) use and may be update existing collaboration tools, like imsim,
+    which produces galaxy images adapted to the LSST telescope and survey conditions.We will
+    carry out the software development as an integral part of the collaboration, reporting
+    regularly on progress, taking input from our colleagues and supporting the collaboration’s
+    members in the use of the code. We have secured the needed amounts of local computing
+    for this work, but will be keen on using DESC computing resources (at NERSC) as they become
+    available to us, to ensure that the code functions at the needed scale. In addition, to
+    ensure that DESC members have read access during all stages of code development we plan
+    to host any code development on DESC GitHub.The primary risk associated with this work
+    is to find high level experts familiar with the complex subject. Since we have such a
+    skilled person in our group now (until summer 2023) we would like to contribute our FTE
+    at the earliest time possible (see below).
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-LMU-S4.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S4.yaml
@@ -1,0 +1,62 @@
+contribution_id: GER-LMU-S4
+title: 'Cluster Finding and Likelihood: development and validation [near-term directable software
+  development]'
+country: Germany
+institute: LMU_Munich
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: Prof. Dr. Weller’s team will contribute directable software development
+    effort in the general area of LSST Dark Energy science cluster cosmology analysis. Depending
+    on the candidates hired and on coordination with the relevant DESC working group, this
+    could e.g. be in the area of defining the likelihood and cluster selection function or
+    validating the cluster finder with additional data and complementary finders or implementing
+    cluster clustering as a probe under consideration of the full covariance. To specify our
+    contribution, we will consult the relevant members of DESC leadership regarding the WG
+    priorities and we will then develop a work plan via mutual agreement. Team members will
+    work with the DESC, particularly the CL, LSS and TJP working groups, to define needed
+    software development tasks. They will then carry out those tasks as an integral part of
+    the collaboration, reporting regularly on progress, taking input from the rest of the
+    collaboration and supporting the collaboration’s members in the use of the code. The Postdocs
+    will make use of standard DESC software tools/tutorials to help them to get engaged with
+    the DESC activities and procedures.We anticipate needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at Munich, also by preferential access
+    to the local computing centers like for example the Leibniz Supercomputing Centre via
+    the Excellence Cluster Origins structure. However, the primary platform for the development
+    and implementation of the software tools will be NERSC as DESC's primary computing center.
+    The primary risk associated with this work is the availability of realistic galaxy cluster
+    catalogs to calibrate the cluster selection function. This can be mitigated with the staff
+    to closely collaborate with the simulations group of LSST-DESC to ensure the useful development
+    of simulations.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-MPE-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-MPE-S1.yaml
@@ -1,0 +1,63 @@
+contribution_id: GER-MPE-S1
+title: Photometric redshift tuned for AGN
+country: Germany
+institute: MPE
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: MPE will contribute directable software development efforts in the
+    area of photo-z computation for AGN identified by the AGN SC using LSST data (via e.g.
+    colors, time variability), or other means (X-rays, radio, MIR etc) combined with LSST.
+    A non negligible fraction of sources that LSST will detect are AGN and a dedicated effort
+    to compute their photo-z will be needed. MPE staff will work with the AGN SC to define
+    the required software development tasks, and then carry out the development. The software
+    to be developed will not be part of any existing infrastructure, but rather a tool made
+    available to the LSST SC and possibly to the entire community. It will be possible to
+    use the tool also on catalogs of galaxies not known to host an AGN. The comparison between
+    the traditional photo-z for galaxies and photo-z for AGN will ensure that peculiar sources
+    are flagged, which may help the scientific output of other SCs. We have reached out to
+    the primary contacts for GAL and DE SCs, who are interested in exploring how this work
+    could benefit their collaborations. We will also contact the SLSC and the TVS SC as they
+    may also be interested in the work. We will liaise with Rubin’s photo-z Coordination Group
+    as needed.MPE will provide regular progress reports on this work to the AGN SC as primary
+    recipients. The software will be fully documented and initial support will be provided
+    for collaboration members in its use. We anticipate needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the required scale. The primary risk
+    associated with this work is in gaining the needed expertise in the VRO tools and data
+    products. To mitigate this, the MPE staff will engage early with any Rubin tutorials provided,
+    and look to be active participants in events associated with the Rubin “Data Previews”,
+    all within the context of the AGN SC, of which the Proposal Lead is already an active
+    member.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astroinformatics
+  - Astronomy software
+  - Photometric redshift
+  - Radio astronomy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/GER-MPE-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-MPE-S2.yaml
@@ -1,0 +1,58 @@
+contribution_id: GER-MPE-S2
+title: MPE efforts to assure reliable photo-z for AGN
+country: Germany
+institute: MPE
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: 'MPE will contribute directable software development effort in the
+    specific area of LSST AGN photometric redshifts. In general this contribution will comprise
+    studies aimed at determining the best way to compute photo-z for AGN enhanced by LSST
+    photometry. Together with the AGN SC and the AGN photo-z group at least two distinct areas
+    that need development have already been identified and for which the expertise of MPE
+    would be valuable. First, the construction and improvement of AGN templates (e.g. templates
+    for obscured AGN). Second, a “recipe” that allows the merging of photometry from different
+    surveys at different wavelengths, depending on e.g., whether the sources are extended
+    or point-like. The latter development should allow reliable photo-z for AGN to be determined
+    as soon as LSST data become available, to enable science while waiting for homogenised
+    photometry (e.g., like that currently offered by Legacy Survey) to become available. These
+    areas have been highlighted from a range of other related efforts towards realising reliable
+    AGN photo-z’s. We will respond flexibly under the guidance of the SC to assist with effort
+    towards the high priority development needed with mutual agreement. The studies will be
+    in synergy and coordinated together with the experts of the AGN SC, to which the MPE group
+    will report periodically.The primary risk associated with this work is in gaining the
+    needed expertise in the Rubin tools and data products: to mitigate this, MPE staff will
+    engage early with any Rubin tutorials provided, and look to be active participants in
+    events associated with the Rubin “Data Previews”, all within the context of the AGN SC.
+    The AGN SC and in particular the AGN photo-z group within the SC has endorsed this proposed
+    contribution.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astronomy software
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/HUN-KON-S2.yaml
+++ b/docs/contribution-types/_data/software/HUN-KON-S2.yaml
@@ -1,0 +1,70 @@
+contribution_id: HUN-KON-S2
+title: Directable Effort in the General Area of Machine Learning Classification and Associated
+  Infrastructure Software
+country: Hungary
+institute: Konkoly
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'The Hungarian LSST Collaboration proposes to allocate directable
+    software development efforts to support the activities within the TVS Science Collaboration.
+    Our staff will work with the TVS SC to define needed software development tasks, and then
+    carry out those tasks as an integral part of the collaboration, reporting regularly on
+    progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code(s). One such contribution might be the development of a
+    machine-learning based classification pipeline to incrementally improve classification
+    of variable point-sources with LSST multicolor light curves as more and more data are
+    coming in during the 10-yr main survey. Since a monolithic classifier would not be able
+    to meet the output purity requirements we propose an iterative modular system with different
+    modules tuned for classification of specific transients and variable stars. We would take
+    advantage of the fact that some of the modules may already be in development in other
+    LSST Science Collaborations and incorporate these when possible in the proposed pipeline.
+    The pipeline would be primarily based on LSST multicolor lightcurves, but would also take
+    advantage of other LSST data products where possible (e.g. real/bogus brokers) as well
+    as data from other surveys. Therefore, we will also work closely with the developers of
+    LSST broker systems. We anticipate needing modest amounts of local computing to support
+    this work, and focus on using Rubin-provided user computing resources as they become available
+    to ensure the code functions at the needed scale. The aforementioned local computing resources
+    are already available at Konkoly Observatory, and we will work to secure additional local
+    resources if needed. The primary risk associated with this work is in gaining the needed
+    expertise in the Rubin tools and data products: to mitigate this, the our staff will engage
+    early with any Rubin tutorials provided, and look to be active participants in events
+    associated with the Rubin “Data Previews”, all within the context of the TVS SC. Also,
+    as Róbert Szabó has been a named PI for more than 3 years, has been an active member of
+    the TVS SC, and participated in the annual Consortium meetings in Tucson (and virtually),
+    he and his small team are already involved in Rubin Obs. activities.Recipient: LSST Transients
+    and Variable Stars Science Collaboration (TVS) This contribution has been endorsed by
+    the TVS Science Collaboration. This idea is supported by Croatian, Hungarian, Serbian
+    and Slovenian institutions sharing similar interests and expertise in time-domain astronomy
+    and astrophysics and willing to commit resources towards its development.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Machine learning
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-ISR-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-ISR-S1.yaml
@@ -1,0 +1,53 @@
+contribution_id: IND-ISR-S1
+title: Science Pipeline Development in the LSST Transients and Variable stars Science Collaboration
+country: India
+institute: IISER
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: IISER Pune will contribute directable software development in the
+    general area of astrophysical transients, focussing primarily on software development
+    for follow up of host galaxies of transients. We will work with the Transient and Variable
+    Stars (TVS) SC to define needed software development tasks, and then carry out those tasks
+    as an integral part of the collaboration, reporting regularly on progress, taking input
+    from the rest of the collaboration, and supporting the collaboration’s members in the
+    use of the code. We anticipate needing significant amounts of local computing to support
+    this work, and focus on using Rubin-provided user computing resources as they become available
+    to ensure the code functions at the needed scale. We expect sufficient our needs will
+    be fulfilled by the local computing resources available at IISER Pune. IISER Pune hosts
+    the PARAMBRAHMA cluster as part of the national supercomputer mission, additionally the
+    PIs have access to appended data storage facilities. Our staff will engage early with
+    any Rubin tutorials provided to gain expertise in handling Rubin specific challenges ,
+    and look to be active participants in events associated with the Rubin “Data Previews”,
+    all within the context of the TVS SC. S1.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxy clusters
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-ITI-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-ITI-S1.yaml
@@ -1,0 +1,50 @@
+contribution_id: IND-ITI-S1
+title: Science Pipeline Development in the LSST AGN Science Collaboration
+country: India
+institute: IIT-Indore
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'IIT Indore will contribute directable software development effort
+    in the general area of LSST Active Galactic Nuclei science analysis, with contributions
+    directed to the two working groups in AGN SC, viz., AGN Variability and Follow-up. IIT
+    Indore staff will work with the AGN SC to define needed software development tasks, and
+    then carry out those tasks as an integral part of the collaboration, reporting regularly
+    on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code.We anticipate needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at IIT Indore, and we will work to secure
+    additional local resources if needed. The primary risk associated with this work is in
+    gaining the needed expertise in the Rubin tools and data products: to mitigate this, the
+    IIT staff will engage early with any Rubin tutorials provided, and look to be active participants
+    in events associated with the Rubin “Data Previews”, all within the context of the AGN
+    SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-ITI-S2.yaml
+++ b/docs/contribution-types/_data/software/IND-ITI-S2.yaml
@@ -1,0 +1,53 @@
+contribution_id: IND-ITI-S2
+title: Science Pipeline Development in the LSST Galaxies Science Collaboration
+country: India
+institute: IIT-Indore
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'IIT Indore will contribute directable software development effort
+    in the general area of LSST Galaxies science analysis, with contributions directed to
+    the science areas involving Active Galactic Nuclei, high redshift galaxies and QSOs, clusters
+    of galaxies (AGN feedback, multiwavelength data, Bayesian forward modeling), deep fields
+    and large scale structures, as mentioned in the Galaxies SC roadmap. IIT Indore staff
+    will work with the Galaxies SC to define needed software development tasks, and then carry
+    out those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, and supporting the collaboration’s members
+    in the use of the code.The development work will be embedded in the Galaxies SC. We anticipate
+    needing modest amounts of local computing to support this work, and focus on using Rubin-provided
+    user computing resources as they become available to ensure the code functions at the
+    needed scale. The aforementioned local computing resources are already available at IIT
+    Indore, and we will work to secure additional local resources if needed. The primary risk
+    associated with this work is in gaining the needed expertise in the Rubin tools and data
+    products: to mitigate this, the IIT Indore staff will engage early with any Rubin tutorials
+    provided, and look to be active participants in events associated with the Rubin “Data
+    Previews”, all within the context of the Galaxies SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-IUC-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S1.yaml
@@ -1,0 +1,54 @@
+contribution_id: IND-IUC-S1
+title: Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: India
+institute: IUCAA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - LSST Strong Lensing Science Collaboration
+  activity_description: 'IUCAA will contribute directable software development effort in the
+    general area of LSST Dark Energy science analysis, with contributions directed to the
+    weak gravitational lensing working group (WG), optical galaxy clusters WG, and the strong
+    gravitational lensing WG. IUCAA staff will work with the Dark Energy SC leadership to
+    define needed software development tasks, and then carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the code.
+    For work related to strong gravitational lensing, we will also consult the Strong Lensing
+    SC to find synergy with Dark Energy SC.The development work will be embedded in the Dark
+    Energy SC. The development will be carried out at DESC computing resources at NERSC to
+    ensure that other Dark Energy SC members can engage effectively with the work while it
+    is in progress. The primary risk associated with this work is in gaining the needed expertise
+    in the Dark Energy SC tools and data products: to mitigate this, the IUCAA staff will
+    engage early with any Rubin tutorials provided, and look to be active participants in
+    events associated with the Rubin “Data Previews”, as well as the Dark Energy SC “Data
+    Challenges”.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-IUC-S2.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S2.yaml
@@ -1,0 +1,49 @@
+contribution_id: IND-IUC-S2
+title: Science Pipeline Development in the LSST Galaxies Science Collaboration
+country: India
+institute: IUCAA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'IUCAA will contribute directable software development effort in the
+    general area of LSST Galaxies science analysis, with contributions directed in the area
+    of low surface brightness (as identified in the Galaxies science roadmap). IUCAA staff
+    will work with the Galaxies SC to define needed software development tasks, and then carry
+    out those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, and supporting the collaboration’s members
+    in the use of the code. We anticipate needing modest amounts of local computing to support
+    this work, and focus on using Rubin-provided user computing resources as they become available
+    to ensure the code functions at the needed scale. The aforementioned local computing resources
+    are already available at IUCAA, and we will work to secure additional local resources
+    if needed. The primary risk associated with this work is in gaining the needed expertise
+    in the Rubin tools and data products: to mitigate this, the IUCAA staff will engage early
+    with any Rubin tutorials provided, and look to be active participants in events associated
+    with the Rubin “Data Previews”, all within the context of the Galaxies SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-IUC-S3.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S3.yaml
@@ -1,0 +1,52 @@
+contribution_id: IND-IUC-S3
+title: Science Pipeline Development in the LSST Transients and Variable stars Science Collaboration
+country: India
+institute: IUCAA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'IUCAA will contribute directable software development effort in the
+    general area of LSST Transient and Variable Stars science analysis, with contributions
+    directed in the area of Galactic and Local Universe transients (as identified in the TVS
+    science roadmap). IUCAA staff will work with the TVS SC to define needed software development
+    tasks, and then carry out those tasks as an integral part of the collaboration, reporting
+    regularly on progress, taking input from the rest of the collaboration, and supporting
+    the collaboration’s members in the use of the code. We anticipate needing modest amounts
+    of local computing to support this work, and focus on using Rubin-provided user computing
+    resources as they become available to ensure the code functions at the needed scale. The
+    aforementioned local computing resources are already available at IUCAA, and we will work
+    to secure additional local resources if needed. The primary risk associated with this
+    work is in gaining the needed expertise in the Rubin tools and data products: to mitigate
+    this, the IUCAA staff will engage early with any Rubin tutorials provided, and look to
+    be active participants in events associated with the Rubin “Data Previews”, all within
+    the context of the Galaxies SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-NCR-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-NCR-S1.yaml
@@ -1,0 +1,53 @@
+contribution_id: IND-NCR-S1
+title: Science Pipeline Development in the LSST Galaxies Science Collaboration
+country: India
+institute: NCRA
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: 'NCRA will contribute directable software development effort in the
+    general area of LSST Galaxies science analysis, with contributions directed to the SED
+    fitting and photometric redshift and Galaxy morphology working groups (WG) via well trained
+    and supervised postdocs. NCRA staff will work with the Galaxies SC to define needed software
+    development tasks, and then carry out those tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration’s members in the use of the code.The development work will
+    be embedded in the Galaxies SC. We anticipate needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at NCRA and we will work to secure additional
+    local resources if needed. The primary risk associated with this work is in gaining the
+    needed expertise in the Rubin tools and data products: to mitigate this, the NCRA staff
+    will engage early with any Rubin tutorials provided, and look to be active participants
+    in events associated with the Rubin “Data Previews”, all within the context of the Galaxies
+    SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/IND-TIF-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-TIF-S1.yaml
@@ -1,0 +1,52 @@
+contribution_id: IND-TIF-S1
+title: Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: India
+institute: TIFR
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'TIFR will contribute directable software development effort in the
+    general area of LSST Dark Energy science analysis, with contributions directed to the
+    dark matter working group (WG), cosmological simulations WG, Theory and Joint Probes WG,
+    and Clusters of Galaxies WG. TIFR staff will work with the Dark Energy SC leadership to
+    define needed software development tasks, and then carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the code.The
+    development work will be embedded in the Dark Energy SC. The development will be carried
+    out at DESC computing resources at NERSC to ensure that other Dark Energy SC members can
+    engage effectively with the work while it is in progress. The primary risk associated
+    with this work is in gaining the needed expertise in the Dark Energy SC tools and data
+    products: to mitigate this, the TIFR staff will engage early with any Dark Energy SC/Rubin
+    tutorials provided, and look to be active participants in events associated with the Rubin
+    “Data Previews” and the Dark Energy SC “Data Challenges”. Some of these contributions
+    could also have relevance and synergy with the AGN SC and the Galaxies SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ISR-UST-S1.yaml
+++ b/docs/contribution-types/_data/software/ISR-UST-S1.yaml
@@ -1,0 +1,49 @@
+contribution_id: ISR-UST-S1
+title: Joint ULTRASAT-LSST Transient Alerts
+country: Israel
+institute: ULTRASAT
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Prompt Processing Group
+  additional_recipient_groups: []
+  activity_description: We propose a handshake mechanism whereby LSST alert brokers and the
+    ULTRASAT alert generator ping a designated server on the collaborating side, providing
+    coordinates and a time stamp, and receiving in return a formatted block that can be included
+    or appended to an outgoing alert, with the information described above. Communication
+    protocols will be set up between the relevant broker teams and the ULTRASAT Science Operations
+    Center (SOC). The connection between ULTRASAT and the AMPEL broker (operated by ULTRASAT
+    core team members at DESY) will be set up by the ULTRASAT team, ensuring at least one
+    operational joint broker by resources included fully in this proposal. For other brokers,
+    development effort needs to be undertaken on the broker side by the relevant broker teams,
+    but the ULTRASAT team will assign additional resources to support development on the broker
+    side with information and advice. As part of the periodic ULTRASAT data releases, ULTRASAT
+    UV light curves will be connected with LSST events (either transients or static sources
+    - e.g., for stellar flares). This will allow curators of LSST data to add the public ULTRASAT
+    light curves to the aggregated information about these LSST sources.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S10.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S10.yaml
@@ -1,0 +1,62 @@
+contribution_id: ITA-INA-S10
+title: 'Directable SW contribution for the SMWLV and TVS SCs: Software Tools for'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups:
+  - LSST Stars Milky Way and Local Volume Science Collaboration
+  - Rubin Crowded Field Coordination Group
+  activity_description: 'We propose to work within the Crowded Fields Working group, and in
+    agreement with the SMWLV and TVS SCs, in the framework of Directable SW, to implement
+    a series of tools focused to obtain accurate photometry in crowded fields. As a proposed
+    example, we mention our experience in the P.B. Stetson’s ALLFRAME code, which simultaneously
+    fits a master star list on a set of images, cross-correlating fluxes (in different passbands)
+    and positions. This approach allows to enhance the accuracy of the photometry, especially
+    at the faint end of the brightness range. We are available to test this approach and other
+    approaches developed to deal with the LSST data, according to the directable nature of
+    our proposed contribution. In general, we are keen to contribute with specific FTEs and
+    our experience on this matter.The INAF proposers will work with the Rubin Team to define
+    needed software development and tasks aimed at tailoring/integrating any existing product
+    on the base of Rubin requirements or to implement specific tools from scratch, by following
+    Rubin requests. They also carry out those tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration’s members in the use of the proposed tool. We anticipate
+    needing modest amounts of local computing to support this work and focus on using Rubin-provided
+    user computing resources as they become available to ensure the code functions at the
+    needed scale. The aforementioned local computing resources are already available at INAF,
+    and we will work to secure additional local resources if needed. The primary risk associated
+    with this work is in gaining the needed expertise in the Rubin tools and data products,
+    both for INAF team staff members and dedicated recruited personnel: to mitigate this,
+    the INAF team will engage early with any Rubin tutorials provided, and look to be active
+    participants in events associated with the Rubin “Data Previews”, all within the context
+    of the TVS and SMWLV SCs.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S11.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S11.yaml
@@ -1,0 +1,56 @@
+contribution_id: ITA-INA-S11
+title: 'Directable SW contribution for the Solar System SC: Advanced active objects’ detection
+  & characterization'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Solar System Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The INAF team will contribute directable software development effort
+    in the general area of Rubin data reduction, focusing on the detection and advanced characterization
+    of active objects. The INAF proposers will work within the context of the SSSC Community
+    Software and Infrastructure Development working group and other relevant working groups,
+    such as the Active Object working group, in order to define and develop the needed SW
+    by tailoring/integrating any existing product on the base of Rubin requirements or by
+    implementing new specific tools from scratch following Rubin requests. They will carry
+    out those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the entire collaboration, and supporting the collaboration’s members
+    in the use of the proposed tool.We anticipate needing modest amounts of local computing
+    to support this work and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at INAF and at Parthenope University,
+    and we will work to secure additional local resources if needed.The primary risk associated
+    with this work is in gaining the needed expertise to adapt the pipeline already at hand
+    to LSST scale. As some of the proposers and the dedicated recruited personnel are not
+    part of the SSSC yet, they will first need to be acquainted with the Rubin data products
+    and build-in pipelines. In order to mitigate this problem, we plan to engage early with
+    Rubin SW developers and look to be active participants in forthcoming Rubin “Data Previews”
+    within the context of the SSSC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Solar system astronomy
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S12.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S12.yaml
@@ -1,0 +1,64 @@
+contribution_id: ITA-INA-S12
+title: 'Directable SW contribution for the SMWLV SC: Machine Learning tools for the characterization
+  of stellar populations'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Stars Milky Way and Local Volume Science Collaboration
+  additional_recipient_groups:
+  - LSST Transients and Variable Stars Science Collaboration
+  activity_description: 'We propose to work closely with the SMWLV and TVS Science Collaborations,
+    and in the framework of Directable software, to implement a series of tools focused at
+    characterising stellar populations. Thanks to our extensive experience in the study of
+    stellar populations through spectroscopy and photometry, we could in particular provide
+    expertise in the development of tools aimed at at the derivation of photometric metallicities
+    of field stars and of parameters of stellar clusters (e.g. age, metallicity, distance
+    etc) from Rubin Observatory data. An endorsement request has been sent to the SMWLV and
+    TVS SCs jointly with contribution S10. We have already obtained a positive response from
+    both collaborations.The INAF proposers will work with the Rubin Team to define needed
+    software development and tasks aimed at tailoring/integrating any existing product on
+    the base of Rubin requirements or to implement specific tools from scratch, by following
+    Rubin’s requests. The proposers intend to exploit their previous experience into the adaptation
+    of the tool to specific Rubin project needs. They also carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the proposed
+    tool. We anticipate needing modest amounts of local computing to support this work, and
+    focus on using Rubin-provided user computing resources as they become available to ensure
+    the code functions at the needed scale. The aforementioned local computing resources are
+    already available at INAF, and we will work to secure additional local resources if needed.
+    The primary risk associated with this work is in gaining the needed expertise in the Rubin
+    tools and data products, both for INAF team staff members and dedicated recruited personnel:
+    to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
+    look to be active participants in events associated with the Rubin “Data Previews”, all
+    within the context of the SMWLV and TSV Science Collaboration.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxy clusters
+  - Machine learning
+  - Spectroscopy
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S13.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S13.yaml
@@ -1,0 +1,54 @@
+contribution_id: ITA-INA-S13
+title: 'Directable SW contribution for the [Galaxies] and [DE] SCs: Advanced tools for extragalactic
+  photometry'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Algorithms & Pipelines Team
+  additional_recipient_groups:
+  - LSST Dark Energy Science Collaboration
+  - LSST Galaxies Science Collaboration
+  activity_description: 'The INAF team will contribute directable software development effort
+    in the general area of Rubin data science analysis and exploration, including advanced
+    methods for photometric measurements of sky sources. The INAF proposers will work with
+    the Rubin Team to define needed software development and tasks aimed at tailoring/integrating
+    any existing product on the base of Rubin requirements or to implement specific tools
+    from scratch, by following Rubin requests. They also carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the proposed
+    tool. We anticipate needing modest amounts of local computing to support this work and
+    focus on using Rubin-provided user computing resources as they become available to ensure
+    the code functions at the needed scale. The aforementioned local computing resources are
+    already available at INAF, and we will work to secure additional local resources if needed.
+    The primary risk associated with this work is in gaining the needed expertise in the Rubin
+    tools and data products, both for INAF team staff members and dedicated recruited personnel:
+    to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
+    look to be active participants in events associated with the Rubin “Data Previews”, all
+    within the context of the I&S SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S14.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S14.yaml
@@ -1,0 +1,59 @@
+contribution_id: ITA-INA-S14
+title: Directable SW contribution for the
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'The INAF team will contribute directable software development effort
+    in the general area of DESC Galaxy Clusters and Simulations working group, in Projects
+    and areas that could also include the creation of an infrastructure to generate, store
+    and make fully accessible to the LSST Collaboration simulations and mocks of the LSST
+    survey, the characterization of optimal filter algorithms for the identification of galaxy
+    clusters in LSST data, the development and validation of software for galaxy cluster mass
+    modelling and scaling relations. The INAF proposers will work with the DESC Team to define
+    needed software development and tasks aimed at tailoring/integrating any existing product
+    on the base of DESC requirements or to implement specific tools from scratch, by following
+    DESC requests and shared with the DESC in GitHub community repositories. They also carry
+    out those tasks as an integral part of the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, and supporting the collaboration’s members
+    in the use of the proposed tool. We anticipate needing local computing to support this
+    work and focus on using DESC-provided user computing resources as they become available
+    to ensure the code functions at the needed scale. The aforementioned local computing resources
+    are already available at INAF, and we will work to secure additional local resources if
+    needed. The INAF proposers will actively work to ensure that all the developed software
+    will also run smoothly at NERSC, DESC’s primary computing host.The primary risk associated
+    with this work is in gaining the needed expertise in the DESC tools and data products,
+    both for INAF team staff members and dedicated recruited personnel: to mitigate this,
+    the INAF team will engage early with any DESC tutorials provided, and look to be active
+    participants in events associated with the Rubin “Data Previews”, all within the context
+    of the DESC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S15.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S15.yaml
@@ -1,0 +1,66 @@
+contribution_id: ITA-INA-S15
+title: Tools for classification, full characterization and validation of variable sources
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The INAF team will contribute directable software development effort,
+    endorsed by Rubin Transients and Variable Stars (TVS), Science Collaboration (SC), in
+    order to provide TVS with an architecture and specific tools for the identification, classification
+    and validation of variable sources observed by the Rubin Observatory. This will include
+    machine/deep learning methods for prediction/classification tasks, as well as tools for
+    cross-matching with existing catalogues, analysis and validation of variable sources.Tools,
+    pipelines and (python-written) procedures we developed in the context of the Variability
+    Unit of the Gaia Data Processing and Analysis Consortium (DPAC) will be re-moduled and
+    adapted for the analysis of the LSST multi-wavelength time series data and/or used to
+    feed machine-learning (python-based) pipelines to validate the classification. The machine
+    learning training set will be based on the vast and accurate training sets that we have
+    developed along the years in the context of the Gaia mission, which will be progressively
+    updated to account for the Rubin-LSST achievements. In parallel, the validation will take
+    full advantage of the huge compilation of literature catalogues (including those produced
+    by previous Gaia releases) which we have been building over the years and constantly update
+    to validate the Gaia products. The proposers will collaborate with the Rubin Team to define
+    needed software developments, to integrate/tailor existing software products or implement
+    specific tools from scratch, based on the Rubin requirements and following Rubin requests.
+    The activity will be carried out in strict collaboration with other members of the LSST
+    TVS SC and taking into account the feedback from the rest of the collaboration. The tools
+    will be developed in the same framework adopted by the Rubin TVS SC in order to ensure
+    compatibility and ease of use and testing. To allow for an efficient development of the
+    proposed software both the INAF team staff members and the dedicated recruited personnel
+    will need to quickly become familiar with the Rubin tools and data products. To this end
+    the INAF team will engage early with any tutorials provided by RO, and will actively participate
+    in events of the TVS SC associated with the Rubin “Data Previews”.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Deep learning
+  - Machine learning
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S2.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S2.yaml
@@ -1,0 +1,65 @@
+contribution_id: ITA-INA-S2
+title: 'Directable SW contribution for the AGN SC: Simulations of high-z AGNs and galaxies
+  in the LSST survey'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'The INAF team will contribute to the AGN SC team with a directable
+    software development effort. This contribution might also be relevant for the Galaxies
+    SC. The aim is to help build an AGN mock catalog which will be used as input, together
+    with the galaxy mock catalog, to simulate LSST images. The AGN mock catalog at the desired
+    depth and with any chosen set of passbands, will be created using the state-of-the-art
+    prescriptions that match observations of AGN in the deep fields. The goal is to create
+    simulated LSST and Euclid FoVs by using GalSim (Rowe et al., 2015) or other tools defined
+    by the SC. Photometric catalogues of sources (AGN and galaxies) will then be extracted
+    from the simulated images in different bands and at different depths. We point out that
+    fluxes will be measured on the simulated images using real photometric software tools,
+    as opposed to being directly simulated in the mock catalog. The INAF proposers will work
+    with the Rubin Team to define needed software development and tasks on the base of Rubin
+    requirements or to implement specific tools, by following Rubin requests. They will also
+    carry out those tasks as an integral part of the AGN science collaboration, reporting
+    regularly on progress, taking input from the rest of the collaboration, and supporting
+    the collaboration’s members in the use of the proposed tool. This work has been weighed
+    against the AGN SC Roadmap document and the criteria outlined in the proposer’s handbook
+    and it has been accepted as a contribution by the AGN SC. Several AGN SC members (i.e.
+    Niel Brandt, Gordon Richards, Jan-Torge Schindler and Franz Bauer) have declared interest
+    and will be involved in the project.We anticipate needing modest amounts of local computing
+    to support this work and focus on using Rubin-provided user computing resources as they
+    become available to ensure the code functions at the needed scale. The local computing
+    resources are already available at INAF, and we will work to secure additional local resources
+    if needed. The primary risk associated with this work is in gaining the needed expertise
+    in the Rubin tools and data products, both for INAF team staff members and dedicated recruited
+    personnel: to mitigate this, the INAF team will engage early with any Rubin tutorials
+    provided, and look to be active participants in events associated with the Rubin “Data
+    Previews” within the context of the AGN SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astroinformatics
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S23.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S23.yaml
@@ -1,0 +1,61 @@
+contribution_id: ITA-INA-S23
+title: 'Staff effort in support of Rubin commissioning: ML tools for instrumental monitoring
+  and analysis'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Commissioning Team
+  additional_recipient_groups: []
+  activity_description: 'The INAF-OACN team will contribute directable software development
+    effort in the general area of LSST focal plane instrument HouseKeeping/telemetry and science
+    analysis, including machine/deep learning methods for prediction/classification tasks,
+    as well as trend analysis and statistical characterization of focal plane instrument and
+    science data/images systems. By considering that a general-purpose version of the proposed
+    system is already in place and a customized version was adopted by ESA Euclid Mission,
+    the proposers intend to exploit their previous experience into the adaptation of the tool
+    to specific LSST project needs. The INAF-OACN proposers will work with the LSST Commissioning
+    Team to define needed software development and tasks aimed at tailoring/integrating the
+    existing product on the base of LSST requirements. In fact, this activity can be activated
+    in a very short time, due to the already available software system on which to work. They
+    also carry out those tasks as an integral part of the collaboration, reporting regularly
+    on progress, taking input from the rest of the collaboration, and supporting the collaboration
+    members in the use of the proposed tool. We anticipate needing modest amounts of local
+    computing to support this work, and focus on using Rubin-provided user computing resources
+    as they become available to ensure the code functions at the needed scale. The aforementioned
+    local computing resources are already available at INAF-OACN, and we will work to secure
+    additional local resources if needed. The primary risk associated with this work is in
+    gaining the needed expertise in the Rubin tools and data products, both for INAF-OACN
+    team staff members and dedicated recruited personnel: to mitigate this, the INAF-OACN
+    team will engage early with any Rubin tutorials provided, and look to be active participants
+    in events associated with the Rubin “Data Previews”, all within the context of the I&S
+    SC.More technical and functional information on the prototype system offered is available
+    here: https://drive.google.com/drive/folders/1iXAoA8OS9G1Srl7erVu9zQ-EdWVm5Rkj?usp=sharing'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Deep learning
+  - Machine learning
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S25.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S25.yaml
@@ -1,0 +1,66 @@
+contribution_id: ITA-INA-S25
+title: 'Non-Directable SW contribution for the [MWLW] SC: Population models of the LSST stellar
+  content'
+country: Italy
+institute: INAF
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Stars Milky Way and Local Volume Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'We will perform large-scale simulations of the stellar content of
+    LSST, based on the latest version of the TRILEGAL population synthesis code. Each simulation
+    is a big catalog of stellar fundamental parameters (masses, ages, metallicities, radii,
+    coordinates, distance, extinction, proper motions, etc), together with photometry in LSST
+    and Gaia filters, for ~19e9 stars in the Milky Way and Magellanic Clouds, down to the
+    r~27.5 mag limit of stacked LSST images.- A first version of these simulations was used
+    to support two Cadence Optimization white papers and the case for developing static crowded
+    field photometry in the context of the SMWLV Science Collaboration. It was partially made
+    available in the NOAO/ASTRO Data Lab in 2019.- A second version of the simulation, significantly
+    more complete and including more information about variability and binaries, is now being
+    finalised. Its density maps were already incorporated in MAF (lsst_sims tag sims_w_2020_05)
+    as an alternative to previous star count models derived from the Galfast code. - We will
+    provide at least 3 other releases of the simulations, in the 2001-2026 period, with complete
+    versions being uploaded to NOIR Data Lab, and ''summary maps'' (e.g., stellar densities
+    as a function of color-magnitude and for different sub-samples of stars) being added to
+    MAF and to any other LSST software where it might become useful. Every new release will
+    take into account improved calibrations of the model parameters coming from many ongoing
+    surveys and later from LSST data itself.- We will keep a database of python notebooks
+    and a helpdesk to help the LSST community to use these simulations for any other goals.-
+    From 2021 on, releases will include additional, newly simulated data: light curves for
+    variables such as Cepheids and RR Lyrae, long period variables (LPVs), and eclipsing binaries,
+    more detailed treatment of interstellar+circumstellar dust, extended non-adiabatic pulsation
+    models (linear and non-linear, in 5 modes) for LPVs and semiregulars.- Other ongoing/planned
+    improvements and tools may be provided on a best-effort basis, like for instance stellar
+    models with a detailed treatment of interstellar+circumstellar dust and fast rotation,
+    tools to identify the best-fit parameters of Milky Way models (in collaboration with the
+    Brazilian team at Linea, who is submitting a separated in-kind request), the space-resolved
+    star-formation history of nearby galaxies, etc. This is a non-directable in-kind contribution
+    endorsed by the SMWLV Collaboration. S25'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S26.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S26.yaml
@@ -1,0 +1,60 @@
+contribution_id: ITA-INA-S26
+title: 'Non-Directable SW contribution for the TVS SC: A Bridge from Gamma to Optical'
+country: Italy
+institute: INAF
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups:
+  - LSST Stars Milky Way and Local Volume Science Collaboration
+  activity_description: 'The Italian National Institute for Astrophysics (INAF) and the Space
+    Science Data Center of the Italian Space Agency (SSDC-ASI) teams will contribute non-directable
+    software development effort in the specific area of LSST TVS analysis in a multi-frequency
+    and multi-messenger context to allow the maximum exploitation of the astrophysical information
+    contained in the data in a high-energy and very-high- energy field. The INAF and SSDC-ASI
+    team proposes to systematically analyze LSST data looking for time resolved optical counterparts
+    of high energy and very high energy sources present in catalogue of, or triggered by,
+    X-ray and gamma-ray satellites or Cherenkov telescopes, including low confidence alerts.
+    Validated results, cross-matched with catalogues hosted and managed by SSDC, will be immediately
+    available to the full LSST community, in a multiwavelength context and remotely accessible
+    through SSDC, for the early scientific exploitation. This project is well in line with
+    similar initiatives undertaken for space missions and for Cherenkov Telescopes already
+    carried on at SSDC within the framework of the general agreement between ASI and INAF
+    for carrying on scientific and technical activities in the center. The computing infrastructure
+    to be dedicated to this project will be provided by both INAF (ASTRI Data Center) and
+    SSDC. The service will be articulated in four different phases: 1) the selection of an
+    input catalog of high energy sources of interest; 2) LSST data retrieving and processing;
+    3) Multiwavelength analysis of the data; 4) Publishing results. The project will be active
+    during the whole LSST survey. Computing resources are already available at INAF/SSDC,
+    and we will work to secure additional local resources if needed. INAF will also provide
+    a dedicated postdoc grant to the project.The TVS SC and SWMLV SC have endorsed this proposed
+    contribution.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S3.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S3.yaml
@@ -1,0 +1,68 @@
+contribution_id: ITA-INA-S3
+title: 'Directable SW contribution for the TVS SC: Development of a software to classify variable
+  stars'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'The INAF team will provide directable software development effort
+    in the area of Rubin data science analysis and classification of stellar variability,
+    contributing to user-support projects to benefit a diverse range of science of interest
+    for the TVS SC. Software effort to help TVS members transfer their data reduction to the
+    Science Platform, will be provided, particularly for TVS members studying variable stars.For
+    example, a potential project could include large catalog queries on the annual data release
+    products, comparing the classifications provided by different brokers in order to compile
+    verified variable stars catalogs.The proposers will make available their expertise in
+    young stellar object variability phenomena in the framework of classification of stellar
+    variability, and the final project will be developed in collaboration with TVS.Details
+    describing the TVS software requirements concerning this science have been discussed in
+    several Sections of the TVS. In particular, Sect. 2.4.1 and Sect. 3.3.5 (Giannini, Bonito
+    &amp; Antoniucci) describe the software requirements and possible follow-up observations
+    to study YSOs with erupting accretion bursts (e.g. EXOrs objects), while 5.2.7 (Bonito)
+    is focused on the variability due to quiescent accretion in YSOs in general discussing
+    the necessary software and synergy with different multi-band facilities to accomplish
+    the characterisation of variability for young stars.The INAF proposers will work with
+    the Rubin TVS SC, reporting regularly on progress, taking input from the SC, and supporting
+    the collaboration’s members in the use of the proposed tool. We anticipate needing modest
+    amounts of local computing to support this work and focus on using Rubin-provided user
+    computing resources as they become. The aforementioned local computing resources are already
+    available at INAF, and we will apply for additional international resources if needed,
+    as made since more than a decade for numerical simulations. The primary risk associated
+    with this work is in gaining the needed expertise in the Rubin tools and data products,
+    both for INAF team staff members and dedicated recruited personnel: to mitigate this,
+    the INAF team will engage early with any Rubin tutorials provided, and look to be active
+    participants in events associated with the Rubin “Data Previews”.Both proposers are members
+    of the Stack Club, (Bonito is the Chair of the TVS Task Force on the Rubin Science Platform
+    Evaluation).'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S5.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S5.yaml
@@ -1,0 +1,55 @@
+contribution_id: ITA-INA-S5
+title: 'Directable SW contribution for the Stars, Milky Way & Local Volume SC: Software for
+  the measure of the optical fluxes from galactic diffuse medium'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Stars Milky Way and Local Volume Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'The INAF team will contribute directable software development effort
+    in the general area of Rubin data reduction, analysis and exploration, including diffuse
+    nebulae photometry optimization, to be prioritized and planned via mutual agreement based
+    on the needs of the Stars, Milky Way & Local Volume Science Collaboration. An endorsement
+    has been obtained from the SMWLV Science Collaboration. The INAF proposers will work with
+    the Rubin Team to define needed software development and tasks aimed at tailoring/integrating
+    any existing product on the base of Rubin requirements or to implement specific tools
+    from scratch, by following Rubin requests. They also carry out those tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the proposed
+    tool. We anticipate needing modest amounts of local computing to support this work and
+    focus on using Rubin-provided user computing resources as they become available to ensure
+    the code functions at the needed scale. The aforementioned local computing resources are
+    already available at INAF, and we will work to secure additional local resources if needed.
+    The primary risk associated with this work is in gaining the needed expertise in the Rubin
+    tools and data products, both for INAF team staff members and dedicated recruited personnel:
+    to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
+    look to be active participants in events associated with the Rubin “Data Previews”, all
+    within the context of the SMWLV SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S6.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S6.yaml
@@ -1,0 +1,67 @@
+contribution_id: ITA-INA-S6
+title: 'Directable SW contribution for the Galaxies SC: Tools for the measurement of surface
+  brightness fluctuations on LSST data'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'Our team will contribute directable software development effort in
+    the general area of Rubin data science analysis and exploration, with a focus on the measurement
+    of SBF. We will work with the Galaxies SC to better identify the needed software development
+    tasks, and then carry out those tasks as an integral part of the collaboration. A key
+    characteristic of any deliverable for our contribute will be the automation, because of
+    the large number of potential targets (any relatively smooth galaxy within ~100Mpc), and
+    of the lengthy and complex procedures to measure SBF.The software efforts will be oriented
+    toward (some of) the following contributes: A detection filter for identifying suitable
+    targets for SBF measurement; A fast and automated procedure to model the brightness profiles
+    of extended galaxies; Tools for automated treating all sources contaminating the SBF signal:
+    dust, foreground stars, background galaxies, globular clusters host in the target galaxy;Automated
+    analysis of the power-spectrum residual frame for the final measure of SBF; Validating
+    the SBF distance estimates on test data (real/simulations);Running the measurement on
+    the data releases, delivery of catalogs to the collaboration, preparing data for the public
+    release.The areas of interest delineated above cover most of the needs for SBF measurement
+    assuming that the tools for deriving some of the other key quantities (e.g. galaxy colors,
+    PSF models, etc.) will be available from Rubin''s data management, or other science collaborations.
+    However, if needed, our team could participate in validating or developing such tools.
+    The primary risk associated with this work is in the quality of the SBF signal: any geometric
+    correlation between pixels introduced during the data reduction stage might badly affect
+    the SBF. Hence, we consider of key importance an early testing stage on data processed
+    with a reduction pipeline similar to the one to be used for the LSST (e.g. HSC-SSP data),
+    or on simulated images. A second risk is the automation of the procedures, which we foresee
+    will require to choose where to place the compromise between quality and quantity (many
+    unsupervised measurements vs less supervised ones). To mitigate these risks, the team
+    will engage early with the DM team to include the SBF detection in the standard measurement
+    pipeline (assuming it is fast enough).We anticipate needing modest amounts of local computing
+    to support this work, during the first stages of the project, in part already available.
+    Other resources will be acquired via national or local funding.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Galaxies
+  - Galaxy clusters
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S8.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S8.yaml
@@ -1,0 +1,59 @@
+contribution_id: ITA-INA-S8
+title: Tools for the simulation of Pulsating Stars
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: Our team will contribute directable software development effort (endorsed
+    by TVS) in the general area of Rubin data science analysis and exploration, with a focus
+    on the development of an infrastructure based on extended model sets along with software
+    tools to interpolate among grids of theoretical templates (e.g. light and radial velocity
+    curves, perios, mean magnitudes and colors etc..…) for pulsating variables. We will work
+    with the TVS SC to better identify the needed software, the interconnectivity with other
+    TVS tools and brokers and then carry out those tasks as an integral part of the collaboration
+    in order to achieve these two fundamental aims:to train the developed tools and infrastructure
+    on the extended and detailed model grids for several classes of pulsating stars built
+    by our team;to extend the same tools and infrastructure to theoretical LSST pulsating
+    stars templates developed by other teams and under the supervision of the TVS Scientific
+    Collaboration.The development of general purpose modeling tools for variable star light-curves
+    and the associated infrastructure will rely on our group’s acknowledged expertise in several
+    classes of pulsating stars, but the work will be closely embedded in the TVS Scientific
+    Collaboration to ensure the general applicability of the resulting software.Moreover,
+    the simulation of LSST pulsating stars of various classes will be useful for classification
+    and characterization purposes in the context of the TVS Scientific Collaboration, including
+    training machine learning classification systems.The importance and the necessity of these
+    types of models and software tools for the future analysis of the LSST data for pulsating
+    stars in different Galactic and extragalactic environments are also described in the TVS
+    Roadmap in the Section 'Transients and variables of the Galactic and Local Intrinsic Universe'.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Machine learning
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/ITA-INA-S9.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S9.yaml
@@ -1,0 +1,61 @@
+contribution_id: ITA-INA-S9
+title: 'Directable SW contribution for the Galaxy and Strong Lensing SC and Data management:
+  Structural parameters with Machine learning'
+country: Italy
+institute: INAF
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups:
+  - LSST Strong Lensing Science Collaboration
+  activity_description: 'The INAF team, located at the Osservatorio Astronomico di Capodimonte
+    in Napoli, proposes to develop a software to derive galaxy structural parameters and galaxy-subtracted
+    images using CNN techniques from Rubin observations. This process aims at complementing
+    the ongoing effort of the Data Management (DM) division of the Rubin Observatory to derive
+    single Sérsic fitting of galaxies and expand this to multi-band and multi-component analyses
+    in a fast and efficient way, contributing to the process of deblending sources and star/galaxy
+    separation. The production of galaxy-subtracted images will be implemented within the
+    LSST strong lensing pipeline.The INAF proposers will work with the Rubin Team to define
+    needed software development and tasks aimed at tailoring/integrating any existing product
+    on the base of Rubin requirements or to implement specific tools from scratch, by following
+    Rubin requests. They also carry out those tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration’s members in the use of the proposed tool. We anticipate
+    needing modest amounts of local computing to support this work and focus on using Rubin-provided
+    user computing resources as they become available to ensure the code functions at the
+    needed scale. The aforementioned local computing resources are already available at INAF,
+    and we will work to secure additional local resources if needed. The primary risk associated
+    with this work is in gaining the needed expertise in the Rubin tools and data products,
+    both for INAF team staff members and dedicated recruited personnel: to mitigate this,
+    the INAF team will engage early with any Rubin tutorials provided, and look to be active
+    participants in events associated with the Rubin “Data Previews”, all within the context
+    of the Galaxy and Strong Lensing Science Collaboration (GSC an SLSC) and DM.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  - Gravitational lensing
+  - Machine learning
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/JAP-JPG-S3.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S3.yaml
@@ -1,0 +1,61 @@
+contribution_id: JAP-JPG-S3
+title: Serving Rubin Science Platform (Development and Support)
+country: Japan
+institute: JPG
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin SQuaRE Team
+  additional_recipient_groups:
+  - Rubin Community Science Team
+  activity_description: In this section, we describe human resources for operation and development
+    of RSP. The hardware resources for RSP are proposed as part of the computing facility
+    for the Lite IDAC, which is described in Section 4.If selected, NAOJ would secure 2 individuals
+    at a 0.5 FTE level each to support RSP (one for 4 years, and the other for 13 years).
+    One is a software engineer who is experienced with deployment of data analysis environments
+    using a combination of a container technology and a Jupyter-based interface over a Kubernetes-based
+    distributed computing system. This individual would contribute, for 4 years, some in development
+    of tools for user support such as a web application with expertise obtained through the
+    ongoing HSC-SSP, as well as deployment of the RSP software suite. The other one is a scientist
+    who will serve throughout 13 years of the survey period as user support to bridge LSST
+    users and NAOJ local support staff. As recommended in the Feedback letter, these two staff
+    would be associated with the Rubin Community Engagement team, and taking functional direction
+    from CE team leadership, while being able to interact well with the SPaRE team[i] that
+    will be evolving and maintaining the Rubin Science Platform. In addition, efforts for
+    software development by the above engineer is supposed to follow a collaborative framework
+    of “General pool of fully directable effort” guided in the Handbook, so that his/her contribution
+    time is fully considered for requesting LSST data rights. Those staff would cooperate
+    with the local support staff under the supervision of the same leading person for the
+    Lite IDAC. The computing system and software would be designed to serve moderate result
+    set support (50 simultaneous access, visualization for 10 million objects and result sets
+    of up to 0.1GB, or different requirements that would be suggested by CEC in the evaluation
+    onwards) as defined in the guideline (https://ldm-554.lsst.io/). Since we will host public
+    data products from HSC-SSP and the upcoming PFS survey in neighboring systems in NAOJ,
+    we would discuss an efficient way to provide access to those products for synergistic
+    work combining those data sets with LSST data.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Data visualization
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/JAP-JPG-S7.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S7.yaml
@@ -1,0 +1,61 @@
+contribution_id: JAP-JPG-S7
+title: Software for calibrating the covariance matrix for large-scale structure probes
+country: Japan
+institute: JPG
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The JPG covariance team led by Masahiro Takada (Kavli IPMU) wants
+    to contribute non-directable software development effort in the specific area of covariance
+    work for large-scale structure probes (weak lensing and galaxy clustering) in the DESC
+    science cases, in close collaboration with the Theory and Joint Probes (TJP) working group
+    of DESC collaboration. The JPG team will run cosmological N-body simulations (especially
+    the so-called separate universe simulations) and develop the emulator package/tools allowing
+    for computation of the response functions for matter-matter, matter-galaxy and galaxy-galaxy
+    correlation functions for an input set of parameters (cosmology, halo occupation distribution,
+    separations and redshift), which can be used to calibrate the super-sample covariance
+    contribution of LSS clustering observables. The JPG covariance developers will work closely
+    with the DESC TJP working group in this software development task, carrying out the work
+    as an integral part of the collaboration, reporting regularly on progress, taking inputs
+    from the rest of the collaboration, and supporting the collaboration’s members in the
+    use of the emulator code/tools. We will use in-house computer resources at Kavli IPMU
+    ,and/or super-computing resources at National Astronomical Observatory of Japan to which
+    the JPG covariance team members have access, to run needing cosmological N-body simulations
+    and develop the code/emulator tools. The JPG covariance team will engage with the DESC
+    TJP tasks/collaboration as soon as possible, once this proposal is approved. We will provide
+    the emulator package/tools in the format specified by the DESC TJP collaboration. The
+    representative of JPG covariance team, Masahiro Takada, has been discussing with DESC
+    TJP co-chairs on this proposed contribution, and we will define specific tasks/work packages
+    of the proposed contributions so that the contribution is smoothly integrated with the
+    existing efforts and software. DESC endorses this contribution, 'Software for calibrating
+    the covariance matrix for large-scale structure probes'.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/JAP-JPG-S8.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S8.yaml
@@ -1,0 +1,69 @@
+contribution_id: JAP-JPG-S8
+title: ML deblending algorithm with ground- and space-based images
+country: Japan
+institute: JPG
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The JPG deblending team led by Hironao Miyatake will contribute non-directable
+    software development effort in the object deblending of Rubin images primarily for reducing
+    systematics in weak lensing measurement and in associated infrastructure works. Our team
+    will develop a machine-learning (ML) based deblending algorithm, using pairs of ground-based
+    and space-based telescope images as a training set, which enables to deblend objects observed
+    by a ground-based telescope alone. We will develop the algorithm using the HSC and Hubble
+    Space Telescope (HST) images and apply the algorithm to the HSC and early LSST data. This
+    software development is a pathfinder for a longer-term joint processing effort when the
+    Nancy Grace Roman Space Telescope comes online. We are currently at the initial stage
+    of the algorithm development. Before obtaining proofs of concept, this development should
+    be counted as research rather than a part of our in-kind contribution.Through this development,
+    we will contribute to the infrastructure work on BTK, which will benefit other groups
+    within the DESC BLWG. Our contribution includes adding capability to simulate pairs of
+    high-resolution and low-resolution realistic galaxy images based on, e.g., real galaxy
+    images from the COSMOS HST data and ML-based generative images (Lanusse et al., arXiv:2008.03833),
+    which is used to validate our deblending algorithm. Through this process, we will validate
+    the completeness of COSMOS input catalog and enhance the COSMOS catalog with the ML-based
+    generative images, which should benefit other DESC projects relying on the COSMOS catalog.
+    Once initial proofs of concept for the deblender are successful, later stages of the algorithm
+    development could be part of this in-kind contribution pending agreement from DESC that
+    this would be a valued infrastructure contribution. We already have GPU machines in Nagoya
+    University used for training deep learning models and have enough funding to purchase
+    additional GPU machines if necessary. We will make sure our deblending algorithm runs
+    on NERSC computers and will run deblending on the HSC and early LSST data within NERSC.
+    A possible major risk is to identify an appropriate ML algorithm for deblending. To lower
+    this risk, we already identified expert consultants at Institute of Statistical Mathematics
+    (ISM) and Nippon Telegraph and Telephone Corporation (NTT) in Japan. We will also consult
+    with ML experts within DESC and the Informatics and Statistics Science Collaboration (ISSC),
+    which ensures this work is well-embedded within DESC and Rubin Observatory.DESC endorses
+    this contribution, with LOI code JAP-JAP-4.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Deep learning
+  - Gravitational lensing
+  - Machine learning
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/JAP-JPG-S9.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S9.yaml
@@ -1,0 +1,52 @@
+contribution_id: JAP-JPG-S9
+title: Directable effort in the SL working group
+country: Japan
+institute: JPG
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - LSST Strong Lensing Science Collaboration
+  activity_description: The JPG strong lensing team led by Masamune Oguri will contribute
+    directable software development effort in the general area of LSST Strong Lensing science
+    analysis. The possible effort includes, but not limited to, contribution to the end-to-end
+    simulations of various types of strong lens systems to characterize the selection function
+    in observations and contribution to strong lens finding tools. The team will work closely
+    with the leadership of DESC SL WG and SLSC to define needed software tasks, and then carry
+    out those tasks as an integral part of the collaboration in the DESC GitHub organization,
+    taking inputs from DESC SL WG and SLSC members and reporting the progress regularly. The
+    work will be carried out within DESC Projects as per the DESC Publication Policy. The
+    team will use DESC tools and tutorials in the initial learning phase to ensure that softwares
+    developed by the team will be smoothly connected with other software efforts in DESC.
+    We anticipate that the effort will require modest amounts of computing resources, which
+    are already available at University of Tokyo and NAOJ, although the team will also use
+    NERSC to ensure broader collaboration engagement. This proposed contribution was developed
+    in consultation with DESC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/MEX-UNA-S1.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S1.yaml
@@ -1,0 +1,62 @@
+contribution_id: MEX-UNA-S1
+title: Science Pipeline Development in the LSST SL AND DE Science Collaboration (Joint)
+country: Mexico
+institute: UNAM
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Strong Lensing Science Collaboration
+  additional_recipient_groups:
+  - LSST Dark Energy Science Collaboration
+  activity_description: MEX-UNA subgroup will contribute directable software development effort
+    to SLSC-DESC jointly, with some focus on dark matter science cases whenever possible.
+    Contributions towards the DESC External Synergies and Dark Matter Analysis WGs are also
+    of our interest. The staff will work with SLSC-DESC to define needed software development
+    tasks, and carry them conjointly with the collaboration, reporting regularly on progress,
+    taking input from the rest of the collaboration, and so on. We anticipate the use of local
+    computing resources, which are already available at the University of Guanajuato and UNAM,
+    and we will work to increase local resources if needed. It is worth mentioning that the
+    MEX-UNA group is also proposing a lite IDAC, which could also be hosting SL data if there
+    is interest or need for it. In addition. for the DESC related work will make use of NERSC,
+    DESC primary computing center, in order to efficiently work in a collaborative manner
+    with other DESC members, and we make sure all developed code runs correctly. Regarding
+    code/software development, we will involve at least two other staff members, one at UNAM
+    and one at UG (to be identified), who are software engineers, that will provide support
+    to the core group. The group will have to develop some of the needed expertise, with the
+    time frame depending on the tasks assigned. To minimize the learning time process, the
+    staff will be actively participating in the SLSC-SCSC activities as early as possible,
+    and will take advantage of DESC and SCSL existing documentation, tools and tutorials.
+    Also, the group will be providing the effort in a progresive way, being the least amount
+    of effort in the first year and increasing it in subsequent years. Activities such as
+    validating, documenting or optimizing existing pieces of software within a broader development
+    team are suitable for the early stages, while well-defined software products could be
+    envisioned for later stages. Finally to engage within DESC and SLSC the team will join
+    the regular telecoms and activities of the SCs as well as to participate actively in all
+    their activities, and make use of their communication tools as well.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Gravitational lensing
+  - Strong gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/MEX-UNA-S2.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S2.yaml
@@ -1,0 +1,56 @@
+contribution_id: MEX-UNA-S2
+title: Science Pipeline Development in the DESC Science Collaboration
+country: Mexico
+institute: UNAM
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: This MEX-UNA subgroup will contribute directable effort to code/software
+    development embedded in LSST DESC, with emphasis on the Photometric Redshifts (Photo-z)
+    and Theory and Joint Probes (TJP) analysis groups. This group will work with the SC to
+    define the needed software development tasks, and carry them out as an integral part of
+    the collaboration, reporting regularly on progress, taking input from the rest of the
+    collaboration, and so on.There is particular interest to contribute with tasks regarding
+    covariance matrices, the development of CCL to compute observables in cosmology, the likelihood
+    pipelines for joint analyses, the DESC single-probe LSS likelihood module, and the pipelines
+    to test models beyond wCDM.This group has access to modest local computing resources already
+    available at the researchers institutions, CINVESTAV and UNAM, which will support the
+    majority of this work. The members of this group have also access to grants and funding
+    to expand some of such resources as the project develops. In addition, we will make use
+    of NERSC, DESC primary computing center, in order to efficiently work in a collaborative
+    manner with other DESC members and verify that all developed codes run correctly. The
+    main risk concerning this proposal is acquiring the expertise needed with the tools and
+    products already in place. To mitigate this, the group will engage early with DESC, looking
+    to be active participants in all the events, and will take advantage of DESC and SCSL
+    existing documentation, tools and tutorials, as well as to join the regular telecoms and
+    make use of their communication tools.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/MEX-UNA-S3.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S3.yaml
@@ -1,0 +1,60 @@
+contribution_id: MEX-UNA-S3
+title: Non-directable Science Pipeline Development in the LSST DE Science Collaboration
+country: Mexico
+institute: UNAM
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'This MEX-UNA subgroup is seeking to contribute a non-directable software
+    development effort to be embedded within DESC. The aim of this proposal is to develop
+    a three point statistics pipeline, whose Software Development Priority will contain the
+    following coding efforts: a) an algorithm to extract the signal from data, b) a prescription
+    to estimate its associated error and c) the modelling of the signal. The first stage of
+    the project is to choose and design an algorithm that would most benefit the LSST science,
+    primarily steered by the TJP WG but also in close coordination with the LSS and WL WGs.
+    At the moment, we envision two possibilities: either a configuration space three point
+    correlation function, perhaps, using a multipole decomposition or its fourier space counterpart,
+    the bispectrum, using spin-weighted spherical harmonics. Depending on the target space
+    and other considerations, the error estimation may be done using semi-analytical approaches
+    or re-sampling methods, and to model the signal, we can use our experience using recent
+    developments in EFT-perturbation theory with a consistent biasing model. However, a more
+    detailed study of the benefits, challenges and scientific goals of the two possibilities
+    should be carried on and detailed in a document, which may also prove useful for further
+    developments to the higher statistics pipeline. During this short design phase we will
+    also assess the computational cost, integration into pre-existing codes and pipelines
+    within DESC. Once the decision has been made in agreement with the relevant DESC Working
+    Groups, we plan to spend most of the promised FTE time working in the three lines of software
+    development described above until their completion, with the corresponding documentation
+    in agreement with the collaboration guidelines. A further phase of enhancements can also
+    take place where one may think of general improvements and model extensions. Long-term
+    maintenance will be provided by the contributors of this proposal and according to the
+    requirements of the recipient working groups.DESC endorses this proposed contribution,
+    MEX-UNA-S3.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/MEX-UNA-S4.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S4.yaml
@@ -1,0 +1,51 @@
+contribution_id: MEX-UNA-S4
+title: Science Pipeline Development in the SMWLV Science Collaboration
+country: Mexico
+institute: UNAM
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Stars Milky Way and Local Volume Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'This MEX-UNA subgroup will contribute with directable effort on software
+    development in the general area of LSST SMWLV. The staff will work with the SMWLV SC to
+    define needed software development tasks, and then carry out such tasks as an integral
+    part of the collaboration, reporting regularly on progress, taking input from the rest
+    of the collaboration, and supporting the collaboration’s members in the use of the code.
+    We have a particular interest in dense regions like the central MW, or stellar clusters,
+    dwarf galaxies and the solar neighborhood.We have local computing resources already available
+    at UNAM, and we will work to secure additional local resources if needed. In parallel,
+    our group is proposing a Lite IDAC and the related resources may be applied to this particular
+    project. As the project progresses we might use resources provided by the SC, and make
+    sure all code/software developed runs in their main computing centers. The primary risk
+    associated with this work is in gaining the needed expertise in the Rubin tools and data
+    products: to mitigate this, UNAM staff will engage early with any Rubin tutorials provided,
+    and look to be active participants in events associated with the Rubin “Data Previews”,
+    all within the context of the SMWLV SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxy clusters
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/MEX-UNA-S5.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S5.yaml
@@ -1,0 +1,60 @@
+contribution_id: MEX-UNA-S5
+title: Science Pipeline Development in the Galaxies Science Collaboration
+country: Mexico
+institute: UNAM
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The MEX-UNA subgrup will provide a non-directable effort to the LSST
+    Galaxies SC in software development, with emphasis on morphological classification (and
+    eventually LSB) through the image analysis and Machine Learning algorithms. The group
+    has enough local computing support at IA-UNAM to develop this work, but as the scale of
+    the products work it might be necessary to use other SC resources, and we will make sure
+    that codes/software run in the main SC computing center.This proposal is divided in two
+    main sections:1- The automatic morphological classification of galaxies and the detection
+    of independent morphological structures like bars, rings, mergers of galaxies, etc. After
+    applying an adequate image processing following the techniques in Hernandez-Toledo et
+    al. (2010), and in combination with supervised/unsupervised CNN-based models (e.g. Alvarado-Gonzalez
+    et al. 2021), we will provide computational tools able to extract, almost in real time,
+    these structures, additionally to the morphological type of these galaxies, for the corresponding
+    analysis by the scientific community.2- The detection and classification of LSB structures,
+    focusing mainly on tidal debris. This project will be a continuation of Project 1, and
+    will be carried out according to the needs of the WG and the availability of deep images.
+    Once the development of Machine Learning algorithms, to detect specific structures of
+    galaxies, is done, they could be applied to detect tidal arms, tidal bridges and other
+    structures within the image and magnitudes limits. The results reached and software developed
+    will be available entirely to the collaboration, to use them with different scientific
+    purposes, and also to carry out improvements after comparisons with other groups, working
+    with the same interests but using different techniques. We would also be interested in
+    applying the described techniques towards synergetic efforts with other SCs, like SLSC.We
+    will be happy to extend our collaboration to other projects and share our experience if
+    that is of benefit to the Galaxies SC. The Galaxies SC have endorsed this proposed contribution.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Galaxies
+  - Machine learning
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/NED-UTR-S2.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S2.yaml
@@ -1,0 +1,71 @@
+contribution_id: NED-UTR-S2
+title: Science Pipeline Development for astrophysical systematics for the LSST DESC Science
+  Collaboration
+country: Netherlands
+institute: Utrecht
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'Chisari’s group will commit 1 FTE-yr non-directable effort towards
+    DESC software pipelines: continuing the development of CCL, ensuring smooth integration
+    to the combined-probes likelihood pipeline, and assessing and providing models for astrophysical
+    systematics (mainly intrinsic alignments) for the successful extraction of cosmological
+    information from weak gravitational lensing with LSST, in the spirit of the DESC Science
+    Roadmap[2] (Chapter 5). Implementation of new intrinsic alignment models in CCL. Currently,
+    CCL incorporates the NLA & standard perturbation theory models (up to one-loop) of intrinsic
+    alignments. Neither can describe the smallest scale alignments, where most of the dark
+    energy information is encoded. The EFT approach we proposed in Vlah, Chisari & Schmidt
+    (2020) incorporates all possible physical contributions to the alignment signal to third
+    order. The modelling on fully nonlinear scales can only be tackled via the halo model,
+    which we have refined in Fortuna et al. (incl. Chisari, 2020) based on recent KiloDegree
+    Survey observations (Georgiou et al., 2019a and 2019b, incl. Chisari). We will implement
+    these models in CCL and perform various validations against our previous results following
+    standard DESC procedure as documented in the CCL paper (Chisari et al., LSST DESC, 2019).
+    Definition of mitigation strategy for LSST. The Theory and Joint Probes (TJP) working
+    group is at the moment constructing the likelihood pipeline for inference of cosmological
+    parameters (“Firecrown”) and an official forecasting code (“Augur”) aimed to carry out
+    assessment of the impact of systematics and modelling choices. Following similar procedure
+    as in the DESC science requirements document, we will use these LSST DESC forecasting
+    and likelihood tools to determine expected cosmological parameter biases in Ωm, σ8, w0,
+    wa depending on the model adopted, knowledge of priors, and the scales utilized for the
+    analysis. We will also work with the collaboration in determining the trade-off with other
+    systematics parameters. The aim will be to demonstrate the robustness of cosmological
+    analyses with LSST.We anticipate the need to make use of the DESC NERSC allocation for
+    these projects, though the usage will in general be minimal compared to the typical investment
+    of the allocation (i.e. no simulations or data processing are needed within our activities).
+    We will report on progress regularly at TJP telecons and collaboration meetings, and invite
+    collaboration through sprint activities.Due to funding limitations (see 2.4.1), we envisage
+    the effort to be non-directable. Nevertheless, we will take into account CCL development
+    status and priorities, and seek feedback from the working group to ensure the contribution
+    is timely and meaningful. Other areas where we can contribute and which have been discussed
+    with LSST DESC leads are: the modelling of baryonic physics and general maintenance of
+    TJP pipelines.The LSST DESC has endorsed this contribution.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/NED-UTR-S3.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S3.yaml
@@ -1,0 +1,44 @@
+contribution_id: NED-UTR-S3
+title: Science Pipeline Development in the crowded field photometry coordination group
+country: Netherlands
+institute: Utrecht
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Crowded Field Coordination Group
+  additional_recipient_groups:
+  - Rubin Algorithms & Pipelines Team
+  activity_description: We will contribute directable software development effort in the area
+    of crowded field photometry. We will work with the crowded field photometry coordination
+    group and the Rubin Algorithms & Pipelines Team to define needed software development
+    tasks , and then carry out those tasks as an integral part of the coordination group,
+    reporting regularly on progress, taking input from the rest of the coordination group
+    and supporting the coordination of group members where we can. We will coordinate with
+    the Rubin Algorithms & Pipelines Team to make sure that the proposed algorithms meet their
+    speed and robustness requirements.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Stellar photometry
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/NED-UTR-S5.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S5.yaml
@@ -1,0 +1,88 @@
+contribution_id: NED-UTR-S5
+title: Construction and maintenance of AGN catalogs to enable early science with LSST alerts
+country: Netherlands
+institute: Utrecht
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups:
+  - NOIRLab CSDC
+  activity_description: We will provide contributed datasets and non-directable software development
+    in the area of AGN identification. The first deliverable is a catalog, which will be ready
+    by the start of transient alert science operations (i.e., when sufficient reference images
+    have been constructed, which are needed to extract alerts from the difference image).
+    Our deadline is much earlier compared to the timeline of catalog production by the AGN
+    SC. This faster timescale is motivated by the needs of TVS to have a catalog of known
+    AGN ready as soon as the stream of alerts starts in earnest. This means this first catalog
+    will be constructed from non-LSST data products. We will work closely with Rubin Observatory
+    staff to embed the catalog into the collaboration infrastructure for alert filtering.
+    The catalog will be made available to all members of the LSST collaboration by incorporating
+    this into NOIRLab. We will advertise and distribute the catalog to the LSST brokers, focusing
+    first on the brokers that most directly serve the US and Chile communities (i.e., ANTARES,
+    ALeRCE). The TVS collaboration has reviewed and endorsed this proposal and requested that
+    we start the process of broker integration as soon as possible (with a prototype catalog).
+    The TVS collaboration acknowledges that this proposed in-kind contribution could “serve
+    as a blueprint for future catalogs and their integration in the discovery of new transients”.
+    During the first year of Rubin alert operations, we will update the known AGN catalog
+    by including Rubin observations from the year prior. At this point, we will have access
+    to time series data from Rubin LSST, which allows us to select AGN based on their variability
+    in LSST data. We will write software that can identify low-level AGN variability in the
+    difference images, using a model that simultaneously fits for variability in all filters.
+    This will yield a valued-added catalog of variability-selected AGN. This effort is complementary
+    to the planned activities of the AGN SC as listed in their Roadmap (and confirmed via
+    recent conversations with active members of the group). The AGN SC current priority is
+    a more theoretical approach (compiling “ground-truth samples”), and is generally focussed
+    on the Deep Drilling fields and measurements based on the total flux. In contrast, this
+    proposed in-kind contribution has a more compressed timeline, is focussed on the full-sky
+    and uses the difference image flux. The AGN SC is aware of this proposal but saw no need
+    for formal endorsement because the science application of the deliverables is strongly
+    geared for the TVS collaboration. However, we will of course coordinate closely with the
+    AGN SC, making sure the lessons learned from our early catalogs are shared. Their in-kind
+    contribution coordinator (Sebastian Hoenig) noted that “Coordinating on the variability
+    selection would absolutely be welcome and appreciated”. The need for early AGN catalogs
+    cannot be overstated, but is often overlooked, which is exactly why we believe this proposed
+    in-kind contribution will be very helpful to increase the (early) scientific output from
+    Rubin Observatory. The need for this catalog is often overlooked because current optical
+    transients surveys (e.g., ASASSN, ZTF) are finding events in much brighter galaxies at
+    lower redshift compared to what will be the yield of LSST. These low-redshifts make AGN
+    identification relatively easy. This might have led to a false sense of security on the
+    efficiency of machine-learning based classifiers for LSST transients (eg, AGN variability
+    was not included in the first set of simulations of the Rubin Observatory transient sky
+    in the PLAsTiCC classification challenge). For the fainter galaxies that dominante the
+    LSST alerts, AGN selection will be more challenging compared to our experience with current
+    surveys. In addition, at the larger distance of LSST alerts, separating AGN flares from
+    off-nuclear events (e.g., supernovae) is also more challenging because the former subtend
+    a larger fraction of the galaxy. By building the best-possible AGN catalog and making
+    this available before the alert stream gets up to full speed, we will avoid a scramble
+    of duplicate efforts from TVS members. The TVS has endorsed this contribution.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astroinformatics
+  - Astronomy software
+  - Supernovae
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/POL-NCB-S2.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S2.yaml
@@ -1,0 +1,64 @@
+contribution_id: POL-NCB-S2
+title: Near-Term Directable computing infrastructure effort for Dark Energy Science Collaboration
+  providing a link between
+country: Poland
+institute: NCBJ
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'NCBJ will contribute directable computing infrastructure effort in
+    the general area of DESC science analysis, in particular science pipelines. NCBJ will
+    work with the DESC SC to define needed computing infrastructure development tasks, and
+    then carry out those tasks as an integral part of the collaboration, reporting regularly
+    on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code. At this point NCBJ anticipates that the main task will
+    revolve around 1/ collaboration with DESC group on a distributed infrastructure, primarily
+    targeted at NERSC; development of this common infrastructure, developed via a work plan
+    in consultation with DESC leadership and would be the primary outcome. The Centre intends
+    to achieve integration with DESC collaborative software efforts using DESC tools and tutorials,
+    enabling the infrastructure to be used for DESC Data Challenges as well as Rubin Data
+    Previews. All code that will be produced will be shared in DESC Community GitHub repositories.
+    A by-product of this collaboration will be also development connected to the local infrastructure:
+    2/ integration of local computing resources (CIŚ) with DESC computation scheme through
+    local IDAC and using local data resources, NCBJ provided IDAC, for the purpose of DESC
+    group, 3/ integration of DESC science pipeline working at the National Energy Research
+    Scientific Computing Center (NERSC) with local resources 4/ providing aid to the members
+    of the DESC group using IDAC located at NCBJ. NCBJ will provide computational resources
+    for (2-4) tasks. The primary risk associated with this work is in gaining the needed expertise
+    in the Rubin tools and data products: to mitigate this, the NCBJ staff will engage early
+    with any Rubin tutorials provided, and look to be active participants in events associated
+    with the Rubin “Data Previews”, all within the context of the DESC SC.If selected, NCBJ
+    would secure funding to hire two IT professionals or highly IT-oriented physicists (2
+    x 0.75 FTE) to give support to DESC infrastructure and DESC group. Ideally, these will
+    be the same individuals overseeing the IDAC at 0.25 of their FTE. The main task for the
+    staff will be to serve DESC infrastructure. This includes installation and maintenance
+    of the software and continuous monitoring of the processes, as well as participation in
+    development of necessary pipelines.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/POL-NCB-S3.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S3.yaml
@@ -1,0 +1,60 @@
+contribution_id: POL-NCB-S3
+title: Science Pipeline Development in the LSST Galaxies Science Collaboration
+country: Poland
+institute: NCBJ
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: 'POL-NCB will contribute directable software development effort in
+    the area of estimation of galaxy photometric redshifts and physical properties. NCBJ will
+    base its work on the g developing version of the CIGALE SED fitting tool and we will further
+    optimise it for the work with the LSST data: primarily object catalogs but potentially
+    also the images. This effort will be led in a close collaboration with the main members
+    of the international CIGALE team, embedded in the Galaxies SC, in particular Dr. Veronique
+    Buat, Dr. Denis Burgarella and Dr. Mederic Bouquien. We anticipate cross-correlating the
+    resultant catalogs with similar datasets obtained by other SCs. NCBJ staff will coordinate
+    the work with the Galaxies SC to define necessary precision of the estimated parameters
+    and possibly to include machine learning algorithms to fasten the process of analysis.
+    The resultant user-generated datasets: catalogs of galaxy photometric redshifts and galaxy
+    properties will be made accessible to the Galaxies SC and, with time, to the whole Rubin
+    Observatory community, via appropriate data access centers, among them the local IDAC
+    (S1). NCBJ anticipates usage of both local computing resources associated with IDAC in
+    CIŚ, and Rubin-provided user computing resources to support this work. The aforementioned
+    local computing resources are already available at NCBJ in CIŚ, and additional computing
+    resources will be added if and when needed. The primary risk associated with this work
+    is in gaining the needed expertise in the Rubin tools and data products: to mitigate this,
+    the NCBJ staff will engage early with any Rubin tutorials provided, and look to be active
+    participants in events associated with the Rubin “Data Previews”, all within the context
+    of the Galaxies SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Galaxies
+  - Machine learning
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/POL-NCB-S4.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S4.yaml
@@ -1,0 +1,62 @@
+contribution_id: POL-NCB-S4
+title: Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: Poland
+institute: NCBJ
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: NCBJ will contribute directable software development effort in the
+    general area of LSST large-scale structure (LSS) analysis. This may include selection
+    and photometric redshift (PZ) estimation of galaxies from the LSST data products (primarily
+    the Object catalogs, but potentially also the images). Polish consortium staff will work
+    with the DESC leadership to identify software infrastructure priorities within LSS and
+    PZ, whether self-contained or as part of broader development efforts. NCBJ will take advantage
+    of the relevant successful developments in the Kilo-Degree Survey (KiDS) collaboration,
+    where the Contribution Lead Dr. Maciej Bilicki has been (co-)leading analyses of a similar
+    type. NCBJ will then carry out the identified tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration’s members in the use of the codes. NCBJ intends to achieve
+    integration with DESC collaborative software efforts using DESC tools and tutorials, and
+    will engage with DESC Data Challenges as well as Rubin Data Previews. The codes will be
+    shared in DESC Community GitHub repositories, to ensure that all DESC members can access
+    them as they are developed. The codes will be prepared to run at NERSC to allow DESC members
+    to engage with the efforts more broadly. The resultant user-generated datasets will be
+    made available to the DESC and, with time, to the whole Rubin Observatory community, via
+    appropriate data access centers, among them the local IDAC (S1).We anticipate using both
+    local computing resources, in particular those associated with the IDAC in CIŚ, and Rubin-provided
+    ones to support this work. The aforementioned local resources are already available at
+    NCBJ in CIŚ, and additional ones will be added if needed. In particular, NCBJ plans to
+    invest into local GPU workstations for the proposed deep-learning developments. In the
+    future, this type of new equipment is aimed to be integrated with the emerging national
+    node for Independent Data Access Center (IDAC).
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/POL-NCB-S6.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S6.yaml
@@ -1,0 +1,53 @@
+contribution_id: POL-NCB-S6
+title: Science Pipeline Development in the LSST AGN Collaboration
+country: Poland
+institute: NCBJ
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups: []
+  activity_description: NCBJ will contribute directable software development effort in the
+    general area of LSST AGN variability science analysis. We will focus on the general area
+    of multi-method time delay determination. Given the expertise of the local group led by
+    the Contribution Lead, and software skills of the postdoctoral fellow who will provide
+    the first stage of this contribution, an exemplary plan for the contributed effort could
+    involve development of a single LSST-adjusted front-end for different packages for quasar
+    lag-recovery methods available and being developed inside the AGN SC. NCBJ will work closely
+    with the AGN SC to define the directions for the development of the needed software, and
+    carry out those tasks as a part of the collaboration, defining milestones and reporting
+    progress. NCBJ will actively seek input from the rest of the collaboration and provide
+    consultations on the use of the new software. The software under development will be tested
+    locally, and subsequent versions will be assimilated into the LSST pipeline. The local
+    computing resources required are already at the group’s disposal and additional resources,
+    if and when needed, will be provided by NCBJ. To acquire the expertise necessary to use
+    the LSST pipeline and its products, Mr. S. Panda has attended a 2-month long LSST Stuck
+    Club program, and he conveyed the acquired knowledge to the rest of the group. NCBJ will
+    actively participate in forthcoming events associated with the Rubin 'Data Previews',
+    all within the context of AGN SC. This plan has been consulted with AGN Science Collaboration.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SER-SAG-S1.yaml
+++ b/docs/contribution-types/_data/software/SER-SAG-S1.yaml
@@ -268,11 +268,14 @@ form_data:
     through the Rubin In-Kind program (Contribution ID SER-SAG-S1). Users are asked to cite
     the QNPy-Latte paper (Raju et al. 2026, Astronomy & Astrophysics; arXiv:2606.09665).
   support: Github, Slack
-  maintenance_plan: Discrete future Data Releases (e.g. DR2)
-  maintenance_notes: repository/release upkeep, bug fixing, dependency updates, and documentation/tutorial
-    maintenance, continued application to new Rubin data releases; user support and occasional
-    training; and dissemination through publications, presentations, and QhX Hub citizen-science
-    activities. Estimated effort ~0.05–0.10 FTE across the team.
+  maintenance_plan: Discrete future software releases
+  maintenance_notes: 'Planned maintenance and scientific application only (no substantial
+    new development): repository/release upkeep, bug fixing, dependency updates, and documentation/tutorial
+    maintenance for QhX, QNPy-Latte, and the QhX Hub; continued application to new Rubin data
+    releases with monitoring of completeness, reliability, and efficiency; user support, occasional
+    training, and support for collaborations; dissemination via publications, presentations,
+    and QhX Hub citizen-science activities. Estimated effort ~0.05–0.10 FTE. Thank you for
+    your time and the opportunity — kind greetings from Belgrade.'
   further_development: 'The delivered contribution (main QhX, the DP1 QhX Hub, and QNPy-Latte)
     is complete and fulfils its planned scope. Further developments: First, reprocessing the
     full catalogue on progressively longer baselines (DP2 onward) to track the persistence,

--- a/docs/contribution-types/_data/software/SER-SAG-S1.yaml
+++ b/docs/contribution-types/_data/software/SER-SAG-S1.yaml
@@ -1,0 +1,370 @@
+contribution_id: SER-SAG-S1
+title: Science Pipeline Development for analysis of variability of celestial sources in the
+  LSST AGN and TVS Science Collaboration
+country: Serbia
+institute: SAGNT
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST AGN Science Collaboration
+  additional_recipient_groups:
+  - LSST Transients and Variable Stars Science Collaboration
+  - Rubin Commissioning Team
+  - Rubin Telescope & Site Team
+  activity_description: The SER-SAG staff will contribute directable software development
+    in the general area of LSST AGN and TVS variability of celestial sources analysis, including,
+    but not limited to, the detection of AGN and TVS periodicity and reverberation mapping
+    from the LSST data products (primarily the Object catalogs and time series, and potentially
+    images).SER-SAG staff will work with the recipients of the AGN and TVS SC to define needed
+    software development tasks, and then carry out those tasks as an integral part of these
+    collaborations, reporting regularly on progress, taking input from the rest of the collaboration,
+    and supporting and training the collaboration’s members in the use of the code. We intend
+    to work flexibly with the recipients following their direction in developing and delivering
+    software products as required. Following the advice of AGN SC point of contact, the exact
+    shape of the directable contribution and a final decision on its endorsement would be
+    pending AGN SC consultation that could not be finished before the 25 September deadline.
+    The TVS SC values SER-SAG directable software efforts, and intends to offer endorsement
+    of SER-SAG proposal to the US agencies.We predict moderate amounts of local computing
+    resources for this work, which are already available at SER-SAG, and we will obtain additional
+    local resources if needed by application to the Institute of physics Belgrade high performance
+    computing center. Additionally we will use opportunities provided by Serbian Ministry
+    of Education Science and Technological development to apply for funds through their recurrent
+    triennial calls IDEJE (e.g. we will submit a proposal ExtraUniverse at the first call
+    with deadline Oct8,2020).Our directable-software contribution to the TVS and AGN SC may
+    move towards the development of an iterative modular classification system for variable
+    stars and transients based on machine learning algorithms. This idea is supported by Croatian,
+    Hungarian, Serbian and Slovenian institutions sharing joint interests and expertise in
+    time-domain astronomy and astrophysics and willing to commit resources towards its development.
+    We concentrate on using Rubin-provided user computing resources upon their availability
+    to optimize and fortify the code functions at the needed scale. The primary risk in this
+    work is in obtaining the needed skills in the Rubin tools and data products. To overcome
+    this, the SER-SAG staff will train early with any Rubin tutorials provided, and be active
+    participants in events associated with the Rubin “Data Previews”, all within the context
+    of the AGN and TVS SC.
+  submitted: true
+  email: andjelka.kovacevic@matf.bg.ac.rs
+  submitter_name: Andjelka Kovacevic
+  target_audience: Specific Science Collaboration (e.g., DESC, TVS, SMWLV)
+  software_name: QhX v0.2.1 (main inkind derivable), additional delierable QNPy-Latte 0.1.0
+  version: null
+  software_url: 'main inkind deliverable software QhX source repository: https://github.com/lionandjelka/QhX1,
+    SER-SAG-S1 GitHub organisation: https://github.com/LSST-SER-SAG-S1/QhX1, additional software
+    QNPy-Latte source repository: https://github.com/rajuaman1/QNPy_Latte, QNPy-Latte package
+    page: https://pypi.org/project/QNPy-Latte/, https://github.com/LSST-SER-SAG-S1/QNPy_Latte'
+  documentation: 'main software deliverable QhX documentation: https://lionandjelka.github.io/QhX1/
+    , QhX closeout software archive: https://doi.org/10.5281/zenodo.17980656, additional software
+    QNPy-Latte https://qnpy-latte.readthedocs.io/en/latest/'
+  verification_testing: 'Verification and validation of SER-SAG-S1 were carried out continuously
+    from FY22 to FY26, progressing from requirement-gathering and unit testing toward dataset
+    validation, operational deployment on Rubin data, and independent peer review. Throughout
+    this entire period (FY22–FY26), the contribution was presented and discussed regularly
+    at LSST AGN Science Collaboration main and subgroup meetings, TVS Science Collaboration
+    and TVS Software Task Force meetings, and at AGN SC conferences and LSST@Europe / regional
+    in-kind workshops, providing sustained external scrutiny of the software design, workflows,
+    and documentation. The year-by-year verification activities were as follows. FY22 — Requirements
+    capture, design review, and module-level testing. Verification type: recipient requirements
+    gathering, expert design review, unit/module testing. A requirements survey was circulated
+    to the TVS and AGN Science Collaborations (28 responses), and several recipients supplied
+    light-curve user cases that informed pipeline requirements. The Software Requirements
+    Document was reviewed with Rachel Street (TVS SC); the pipeline synopsis was shared with
+    Eric Bellm, Poshak Gandhi, and Michael Johnson; and Will Clarkson advised adopting the
+    Johnson et al. (2019) approach for quick assessment of cadence influence on detected periods,
+    that is incorporated and cited in the QhX software paper. Core modules (WWZ and superlet
+    wavelets, wavelet cross-correlation, 2D-heatmap integration, FWHM-based period uncertainties,
+    and significance via decoherence and bootstrap/GEV) were implemented and tested individually.
+    FY23 — Dataset validation and signal-injection testing. Verification type: validation
+    on simulated and observational data; injection–recovery testing. QhX and additional code
+    QNPy were validated on LSST AGN Data Challenge and Gaia quasar light curves during COST
+    Action MW-GAIA short-term scientific missions of Andjelka Kovacevic and Dragana Ilic with
+    the Croatia Participation Group (CPG, Ruđer Bošković Institute, Croatia), producing the
+    first numerical and visual period catalogues (10–500 day range). Artificial binary-merger
+    periodic signatures were injected after communication with Jessie Runnoe during LSST@Europe5,
+    to test recovery. Compatibility with the multiband Lomb–Scargle periodogram was demonstrated
+    in the peer-reviewed study of Fatović et al. (2023, AJ, 165, 138). The statistical robovetter
+    (stratification of reliable / medium / poor constrained periods, using significance, asymmetric
+    errors, and the IoU metric) was implemented and validated. FY24 — Integration testing,
+    public demonstration, and packaging. Verification type: integration/usability testing,
+    recipient-facing demonstration, release validation. QNPy v0.0.2 (with SOM integration)
+    was released (25 March 2024) and QhX issued its first public test release (8 April 2024),
+    including dynamic handling of arbitrary filter numbers (validated on a Gaia example) and
+    PEP 517 packaging. Following a Rubin in-kind reviewer recommendation, the team held a
+    virtual public demonstration of QhX and QNPy (4 April 2024) with tutorials, installation
+    guidance, and example workflows (recordings available), directly improving documentation
+    and user-facing materials. The pilot QNPy-Latte (attentive latent neural process) release
+    followed. Full QhX software requirements and design documentation were completed. FY25
+    — Continuous integration, benchmarking, and Rubin DP1 deployment. Verification type: automated
+    Continuous Integration / Continuous Deployment (CI/CD) testing, benchmark cross-validation,
+    operational deployment. The QhX codebase incorporated GitHub CI/CD workflows, automated
+    tests, static code analysis, and dynamic-filter validation, with subsequent ZTF and batch-processing
+    tests on the HPC BURA (University of Rijeka), HPC VEGA (University Nova Gorica, Slovenia)
+    and HPC AI Platform (Serbia) environments. QhX was then deployed on Rubin DP1 quasar light
+    curves after implementing the external-catalogue cross-match workflow (with Neven Caplar
+    LSDB) and catalogue-validation metrics; the project "First Catalog of Periodic AGN Candidates
+    from LSST DP1" was reviewed and approved by the AGN Science Collaboration Publication
+    Committee. An expert seminar on QhX and QNPy was delivered to the Astrophysics group of
+    Dr Maria Charisi at FORTH, Crete (May 2025), providing independent expert assessment.
+    FY26 — Catalogue validation, community data challenges, and peer review. Verification
+    type: end-to-end catalogue validation, blind community-challenge testing, independent
+    peer review. The DP1 QhX coherent/quasi-coherent AGN variability catalogue and web portal
+    were finalised, supported by an offline validation pipeline (schema and value-range checks
+    before promotion), 34 FEETS light-curve features, interactive 2D/3D diagnostics, a secured
+    ORCID-authenticated portal, and published technical documentation (Stanković Cerović et
+    al. 2025). The QNPy was exercised in recipient-defined community data challenges (AGN
+    SC Reverberation Mapping Data Challenge, results submitted April 2026), providing independent
+    blind tests. Independent external review was completed through publication of QhX in the
+    Journal of Open Source Software (Kovacevic et al 2026 JOSS), acceptance of the QNPy-Latte
+    paper in Astronomy & Astrophysics (Raju et al 2026 A&A accepted), and acceptance of QhX
+    DP1 catalogue study in ApJSS (Kovacevic et al 2026 ApJSS accepted). Recipient feedback
+    and resulting improvements. Feedback across FY22–FY26 was iterative, namely via discussions,
+    demonstrations, reviewer recommendations, and use-case testing. The feedback emphasised
+    clear documentation, reproducible notebooks, support for variable filter numbers, robust
+    handling of sparse/gappy/outlier-affected light curves, scalable parallel/batch processing,
+    and Rubin-oriented data-access compatibility. These were incorporated through expanded
+    documentation, public training materials, dynamic-filter support, outlier-handling routines,
+    CI/CD and automated tests, parallelisation, external-catalogue cross-matching, and the
+    DP1 catalogue deployment. We provide reviewer comments for QhX accepted in JOSS: https://github.com/openjournals/joss-reviews/issues/8163#issuecomment-3703916122
+    Also all AGN SC members comments are incorporated in the accepted paper of QhX in ApJSS.
+    We provide in full the Reviewer report on the QhX paper that is accepted in ApJSS (2026):
+    I recommend publication of "QhX Catalogue of Coherent and Quasi-Coherent AGN Variability
+    from Vera C. Rubin LSST DP1" by A.B. Kovacevic et al. for publication in The Astrophysical
+    Journal Supplement Series. The paper details an important framework and tools for the
+    robust investigation of the variability properties of AGN and other objects that researchers
+    will find indispensable in the exploration of the huge datasets LSST and other large survey
+    programs will furnish to the community. Independent academic use (PhD, Master''s, interdisciplinary
+    master courses and internship projects) provided additional tests of portability, reproducibility,
+    and usability outside the core team'
+  sharing_of_software: 'SER-SAG-S1 software was shared openly with the recipient community
+    throughout development (FY22–FY26), following an open-source-from-the-start model. All
+    codes were developed in public repositories, released through standard package indices,
+    accompanied by public documentation and tutorials, and advertised continuously through
+    the LSST AGN and TVS Science Collaborations. Throughout this period the packages were
+    announced on AGN SC and TVS SC Slack channels and mailing lists, and presented at AGN
+    SC main and subgroup meetings, the TVS Software Task Force, and at LSST@Europe and regional
+    in-kind workshops. The team participated virtually at the annual Rubin-wide community
+    meeting throughout the reporting period — the Rubin Observatory Project and Community
+    Workshop (PCW), renamed the Rubin Community Workshop (RCW) from 2024. The year-by-year
+    sharing activities were as follows. FY22 — Open repositories and early community advertisement.
+    Sharing type: public source repositories, direct recipient outreach, community presentation.
+    The QhX pipeline was developed openly under the LSST-SER-SAG GitHub organisation (periodicities,
+    cnp_agn repositories) and made visible to recipients from the outset. The contribution
+    was advertised directly to recipient groups via a survey to the TVS and AGN SCs (28 responses,
+    several returning their own light-curve user cases), and presented at the LINCC Tech Talks
+    (Nov 2022), the AGN SC Summer Workshop, the TVS Software Task Force in-kind workshop,
+    and the LSST@Europe 4 AGN SC parallel session, with a dedicated open forum on periodicity
+    mining (~50 LSST participants). FY23 — Shared catalogues, demonstration notebooks, and
+    published application. Sharing type: public demonstration notebooks, shared data products,
+    peer-reviewed publication. Pilot QhX notebooks for the AGN Data Challenge and Gaia QSO
+    workflows were released publicly for hands-on use, together with the first numerical and
+    visual period catalogues (10–500 days) produced during the MW-GAIA missions with the CPG
+    group. The QNPy application to the LSST AGN Data Challenge was published openly (Kovačević
+    et al. 2023, Universe, 9, 287), and the contribution was presented at LSST@Europe 5 (In-kind
+    session) and multiple international conferences. Kovačević presented the periodicity pipeline
+    at the LINCC Tech Talks (4 November 2022) from 33min https://www.youtube.com/watch?v=o_VEAwg_xK0
+    FY24 — Package releases, public training demo, and documentation. Sharing type: public
+    package releases (PyPI), live community training, released documentation. QNPy v0.0.2
+    was released on PyPI (25 March 2024); QhX issued its first public release on PyPI Test
+    (8 April 2024) and a dynamic-filter PyPI release; and the QNPy-Latte pilot was released
+    on PyPI/GitHub (rajuaman1/QNPy_Latte). Following a Rubin in-kind reviewer recommendation,
+    the team ran an open virtual demonstration of QhX and QNPy (4 April 2024) for LSST community
+    members and students, covering installation, tutorials, and example workflows, with recordings
+    made publicly available. Full software requirements, design documentation, and GitHub.io
+    documentation were published. All resources were consolidated under the public LSST-SER-SAG-S1
+    GitHub organisation, and the work was presented at the LSST AGN SC Summer Meeting (Torino)
+    and LSST@Europe6. FY25 — Peer-reviewed software release and operational catalogue sharing.
+    Sharing type: peer-reviewed open-source publication, CI/CD-backed public repository, shared
+    Rubin DP1 results. QhX completed Journal of Open Source Software review and was released
+    as a peer-reviewed, openly licensed (CC BY 4.0) package with CI/CD, automated tests, and
+    public documentation; QNPy-Latte was released on PyPI and submitted to A&A. First DP1
+    QhX results were shared with the community at the LSST Regional Workshop (Konkoly) and
+    the AGN SC parallel session at LSST@EU7 (Poznań), and reported at the AGN SC telecon and
+    the Fifth Rubin Science Workshop. The "First Catalog of Periodic AGN Candidates from LSST
+    DP1" was approved as an AGN SC project, making the results a shared collaboration product.
+    FY26 — Public catalogue portal, VO interoperability, and published outputs. Sharing type:
+    public web portal, Virtual Observatory services, peer-reviewed publications, public outreach.
+    The QhX Hub, an interactive, versioned, VO-compatible AGN variability catalogue, was made
+    available online with published technical documentation (Stanković Cerović et al. 2025),
+    accessible to Data Rights Holders via ORCID authentication, with programmatic access through
+    IVOA-compliant TAP and ConeSearch services (interoperable with TOPCAT and pyVO). The Hub
+    was presented to the AGN SC meeting, then at AGN SC 2026 Annual Conference (Crete) and
+    demonstrated publicly at the opening of the new Serbia AI Platform supercomputer. The
+    QNPy-Latte paper was accepted in A&A (2026, in production) and the QhX DP1 catalogue manuscript
+    was accepted to ApJSS (2026, in production), completing the open publication of the methods
+    and results. Community use. Beyond the core team, the software has been used and extended
+    by the wider community: in recipient-defined data challenges (AGN SC Reverberation Mapping
+    and Periodicity challenges, TVS TDE classification challenge); by external groups and
+    students through the public repositories and tutorials; and in postgraduate, Master''s,
+    PhD, and internship projects. The DP1 catalogue is an AGN SC-approved shared product available
+    to Data Rights Holders, and the peer-reviewed JOSS and ApJSS release ensures long-term,
+    citable community access. The 2D-hybrid method has also been adopted beyond astronomy
+    (e.g., VLF signal analysis), demonstrating uptake outside the original recipient domain.'
+  publications: 'Published papers/white papers 1.Čvorović-Hajdinjak, I., Kovačević, A. B.,
+    Ilić, D., Popović, L. Č., Dai, X., Jankov, I., Radović, V., Sánchez-Sáez, P., & Nikutta,
+    R. (2022). Conditional Neural Process for nonparametric modeling of active galactic nuclei
+    light curves. Astronomische Nachrichten, 343, e210103. https://doi.org/10.1002/asna.20210103
+    Foundational QNPy paper introducing conditional neural-process modelling for AGN light
+    curves. 2.Breivik, K., Connolly, A. J., Ford, K. E. S., Jurić, M., Mandelbaum, R., Miller,
+    A. A., Norman, D., Olsen, K., O’Mullane, W., Price-Whelan, A. M., et al. (2022). From
+    Data to Software to Science with the Rubin Observatory LSST. arXiv:2208.02781 [astro-ph.IM].
+    https://doi.org/10.48550/arXiv.2208.02781 Community white paper arising from the LINCC
+    workshop, outlining priority software needs for early Rubin science, including scalable
+    time-series analysis. 3. Kovačević, A. B., Radović, V., Ilić, D., Popović, L. Č., et al.
+    (2022). The LSST Era of Supermassive Black Hole Accretion Disk Reverberation Mapping.
+    The Astrophysical Journal Supplement Series, 262, 49. https://doi.org/10.3847/1538-4365/ac88ce
+    Scientific and simulation framework underpinning the photometric reverberation-mapping
+    applications developed in QNPy-Latte, and effects of cadences that were important for
+    development of QhX. 4.Kovačević, A. B., Ilić, D., Popović, L. Č., Radović, V., Jankov,
+    I., Yoon, I., Caplar, N., Čvorović-Hajdinjak, I., & Simić, S. (2021). On possible proxies
+    of AGN light-curves cadence selection in future time domain surveys. Monthly Notices of
+    the Royal Astronomical Society, 505, 5012–5028. https://doi.org/10.1093/mnras/stab1595
+    This peer-reviewed study established cadence-aware metrics for evaluating the recovery
+    of AGN time-domain observables, including photometric time lags, periodicity, and structure
+    functions, under LSST-like observing strategies. 5.Kovačević, A. B., Ilić, D., Popović,
+    L. Č., Andrić Mitrović, N., Nikolić, M., Pavlović, M. S., Čvorović-Hajdinjak, I., Knežević,
+    M., & Savić, Đ. V. (2023). Deep Learning of Quasar Lightcurves in the LSST Era. Universe,
+    9, 287. https://doi.org/10.3390/universe9060287 Application and validation of the QNPy
+    framework using the LSST AGN Science Collaboration Data Challenge. 6.Fatović, M., Palaversa,
+    L., Tisanić, K., Thanjavur, K., Ivezić, Ž., Kovačević, A. B., Ilić, D., & Popović, L.
+    Č. (2023). Detecting Long-period Variability in the SDSS Stripe 82 Standards Catalog.
+    The Astronomical Journal, 165, 138. https://doi.org/10.3847/1538-3881/acb596 Related QhX
+    validation and comparative work on long-period variability detection in survey time-series
+    data. 7.Kovačević, A. B. (2025). Two-Dimensional (2D) Hybrid Method: Expanding 2D Correlation
+    Spectroscopy (2D-COS) for Time Series Analysis. Applied Spectroscopy, 79, 91–104. https://doi.org/10.1177/00037028241241308
+    Methodological foundation of the nonlinear wavelet cross-correlation approach implemented
+    in QhX. 8.Čvorović-Hajdinjak, I. (2024). Modeling Quasar Variability through Self-Organizing
+    Map-Based Process. Serbian Astronomical Journal, 208, 17–27. https://doi.org/10.2298/SAJ2408017C
+    QNPy-related work demonstrating the role of Self-Organizing Maps in improving neural-process
+    modelling of quasar light curves. 9. Kovačević, A. B., Ilić, D., Tošić, M., Pavlović,
+    M., Raju, A., Nikolić, M., Simić, S., Čvorović-Hajdinjak, I., & Popović, L. Č. (2026).
+    QhX: A Python package for periodicity detection in red noise. Journal of Open Source Software,
+    11, 8163. https://doi.org/10.21105/joss.08163 Peer-reviewed software paper describing
+    the QhX package, its 2D period-period analysis, statistical validation, dynamic-filter
+    support, and large-scale processing capabilities. Accepted /in press papers 10.Raju, A.
+    N., Kovačević, A. B., Ilić, D., Tombesi, F., Popović, L. Č., Slezak, E., Sanchez-Saez,
+    P., Pavlović, M., Čvorović-Hajdinjak, I., Simić, S., & Savić, Đ. (2026). A Meta-Learning
+    Framework for Multitask Reverberation Mapping in Active Galactic Nuclei. Astronomy & Astrophysics,
+    accepted. https://arxiv.org/abs/2606.09665 Paper describing QNPy-Latte, combining Self-Organizing
+    Maps, Attentive Latent Neural Processes, and mixture-density modelling for light-curve
+    reconstruction, transfer-function recovery, and SMBH-parameter inference. 11. Fatović,
+    M., Kovačević, A. B., Ilić, D., & De Cicco, D. (2026). Testing period diagnostics on quasar
+    periodic candidates in the era of large surveys. Serbian Astronomical Journal, accepted
+    for publication. This paper applies QhX alongside multiband Lomb–Scargle and complementary
+    variability diagnostics to extended multi-survey light curves from SDSS, Pan-STARRS1,
+    DES, and ZTF. 12. Kovačević, A. B., Ilić, D., Meštrić, U., et al. (2026). QhX Catalogue
+    of Coherent and Quasi-Coherent AGN Variability from Vera C. Rubin LSST DP1. Manuscript
+    accepted at The Astrophysical Journal Supplement Series. Scientific application of QhX
+    to Rubin Data Preview 1, describing the multiband AGN variability catalogue and QhX Hub
+    infrastructure. Community technical note 13.Kovačević, A., Ilić, D., Jankov, I., Popović,
+    L. Č., Yoon, I., Radović, V., Caplar, N., & Čvorović-Hajdinjak, I. (2021). LSST AGN SC
+    Cadence Note: Two metrics on AGN variability observable. arXiv:2105.12420 [astro-ph.GA].
+    https://doi.org/10.48550/arXiv.2105.12420 . It provides a methodological basis for the
+    simulated AGN light curves and cadence-aware validation used in the SER-SAG-S1 QhX and
+    QNPy/QNPy-Latte development programme.'
+  acknowledgements: 1.This work makes use of the QhX (Quasar harmonic eXplorer) software (https://github.com/LSST-SER-SAG-S1/QhX1),
+    developed as a contribution to the Rubin community through the Rubin In-Kind program (Contribution
+    ID SER-SAG-S1). Users are asked to cite the QhX software paper (Kovačević et al. 2026,
+    Journal of Open Source Software, doi:10.21105/joss.08163, Kovačević et al. 2026,ApJSS
+    ) and the papers describing the underlying method (Kovačević et al. 2018, MNRAS, 475,
+    2051; Kovačević et al. 2019, ApJ, 871, 32;). 2.This work makes use of the QNPy-Latte software
+    (https://github.com/rajuaman1/QNPy_Latte), developed as a contribution to the Rubin community
+    through the Rubin In-Kind program (Contribution ID SER-SAG-S1). Users are asked to cite
+    the QNPy-Latte paper (Raju et al. 2026, Astronomy & Astrophysics; arXiv:2606.09665).
+  support: Github, Slack
+  maintenance_plan: Discrete future Data Releases (e.g. DR2)
+  maintenance_notes: repository/release upkeep, bug fixing, dependency updates, and documentation/tutorial
+    maintenance, continued application to new Rubin data releases; user support and occasional
+    training; and dissemination through publications, presentations, and QhX Hub citizen-science
+    activities. Estimated effort ~0.05–0.10 FTE across the team.
+  further_development: 'The delivered contribution (main QhX, the DP1 QhX Hub, and QNPy-Latte)
+    is complete and fulfils its planned scope. Further developments: First, reprocessing the
+    full catalogue on progressively longer baselines (DP2 onward) to track the persistence,
+    phase stability, and secular drift of candidate signals and enable population-level studies
+    of coherent AGN variability. Second, deeper integration between QhX and QNPy-Latte and
+    with complementary spectroscopic, radio, and X-ray datasets, to link coherent optical
+    variability to black-hole mass, accretion state, and multi-wavelength behaviour. We anticipate
+    that near-future software development will enable this. Finally, adding citizen-science-oriented
+    portal features to the QhX Hub. These directions build directly on the completed contribution
+    and could be pursued in future Rubin data cycles, potentially as a follow-on or renewed
+    in-kind activity.'
+  other_feedback: We warmly thank the Rubin In-Kind Program team, the IPCs, and the AGN and
+    TVS Science Collaborations for their support, guidance, and feedback throughout this contribution.
+    It has been a privilege to contribute to the Rubin community, and we look forward to continuing
+    to support LSST science.
+  uat_category:
+  - Astronomy software
+  - Astrophysics
+  - Exoplanet astronomy
+  - Stellar astronomy
+  - Planetary science
+  - Solar system
+  uat_concepts: Active galactic nuclei16 --- Astroinformatics78 --- {Sky surveys}{1464}--Catalogues205
+    --- Astrostatistics1882 --- Light curves 918 --- {Period search}{1955}---{Photometry}{2168}---{Time
+    series analysis}{1916}}
+  associated_dataset:
+    submitted: true
+    data_type:
+    - Value-Added Catalogs
+    data_volume: The current QhX Hub is based on known quasars in LSST DP1. Of approximately
+      1,500 cross-matched quasars, 428 met the sampling criteria and form the analysed sample.
+      For these sources the Hub stores statistical results (object-level and per-band tables,
+      including light-curve features and coherence/vetting metrics) together with per-object
+      images and interactive plots. The current total data volume is of order a few hundred
+      megabytes, dominated by the image and interactive-plot products; it will scale with
+      successive LSST Data Releases.
+    data_schema_link: https://zenodo.org/records/18248330
+    hosting_location: It resides on data cloud machine at University of Kragujevac that is
+      obtained through TVS SC Kickstarter grant https://faculty.washington.edu/ivezic/lsst/LOI2022Plitvice/Simic_Regional_Storage_Support_for_LSST_Related_Science.pdf
+    access_url: https://ser-sag.pmf.kg.ac.rs:8081/agn_catalogue.php
+    access_mechanisms:
+    - TAP / Virtual Observatory Service
+    - API
+    - Web Portal / Interface
+    authentication: Rubin Data Rights verification (RSP authentication)
+    generation_methods: 'Generated with the QhX pipeline delivered under this contribution
+      (ID SER-SAG-S1): wavelet (WWZ) time–frequency analysis + 2D period–period cross-correlation
+      with statistical vetting (significance, period-error bounds, IoU). Input DP1 light curves
+      selected by cross-matching DP1 sources (via LSDB) with external AGN catalogues (DESI,
+      Quaia, MilliQuas, ZTF/QZO); products served through the QhX Hub. Software: https://github.com/LSST-SER-SAG-S1/QhX1
+      (Kovačević et al. 2026, JOSS, doi:10.21105/joss.08163), Catalogue: Kovačević et al.
+      2026 (ApJS, accepted). Docs: Cerovic et al 2026 doi:10.5281/zenodo.17914817.'
+    validation_limitations: 'QA in Kovačević et al. 2026 (ApJS, accepted): permutation significance,
+      cross-band IoU consistency, sinusoidal vetting (SN larger 1.5, phase-lag larger than
+      0.10), FDR control (Benjamini–Hochberg, none rejected); reliability via Dawid–Skene
+      (0.023) and alias-floor (0.975) purity. Limitations: prototype DP1 catalogue; 7-week
+      baseline, possible to infer day-scale only; strong diurnal aliasing (0.5, 1, 2 d); sample
+      g,r,i,z larger than 50 epochs (428 of1,456; u/y excluded); conservative (1 strong +
+      15 medium of 230); asymmetric baseline-limited period errors.'
+    tutorials_docs: Catalogue functioQhX Hub (https://ser-sag.pmf.kg.ac.rs:8081/agn_catalogue.php,
+      doi:10.5281/zenodo.17914817),
+    support_channel: agncatalogue.sersag@gmail.com.
+    citation: 'Citation. Users of the QhX AGN variability catalogue / QhX Hub should cite
+      the catalogue paper (Kovačević et al. 2026, ApJSS ) and its technical documentation
+      (Stanković Cerović et al. 2025, Zenodo, doi:10.5281/zenodo.17914817). Acknowledgement.
+      In addition to the citations above, please include: "This work makes use of data/software
+      products from the QhX contribution, developed as a contribution to the Rubin community
+      through the Rubin In-Kind program, with contribution ID SER-SAG-S1." License. The catalogue
+      data products are open-access; access to the full catalogue via the QhX Hub is granted
+      to Rubin Data Rights Holders on request (ORCID authentication), consistent with Rubin
+      data-rights policy.'
+    maintenance_plan: Discrete future Data Releases (e.g. DR2)
+    maintenance_notes: repository/release upkeep, bug fixing, dependency updates, and documentation/tutorial
+      maintenance, continued application to new Rubin data releases; user support and occasional
+      training; and dissemination through publications, presentations, and QhX Hub citizen-science
+      activities. Estimated effort ~0.05–0.10 FTE across the team.
+    final_report: The final/completion summary was included in the FY26 Q3 Quarterly Update
+      (June 2026), which reported completion of the QhX software and QhX Hub development (along
+      QNPy/Latte) and the transition to maintenance. It was also reflected in the FY25 Annual
+      Evaluation, which stated the contribution had delivered the fully operable pipeline
+      and entered the maintenance and deployment phase.
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astroinformatics
+  - Astronomy software
+  - High performance computing
+  - Machine learning
+  - Time domain astronomy
+  - Transient detection
+  - Variable stars
+  summary: null
+  status_override: null
+  related_contribution_ids:
+  - SER-SAG-S1

--- a/docs/contribution-types/_data/software/SER-STG-S1.yaml
+++ b/docs/contribution-types/_data/software/SER-STG-S1.yaml
@@ -1,0 +1,54 @@
+contribution_id: SER-STG-S1
+title: Credit for past contribution to the LSST by Serbian Technical Group (STG)
+country: Serbia
+institute: STG
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: Rubin Prompt Processing Group
+  additional_recipient_groups:
+  - Rubin Alert Production Group
+  activity_description: Following agreement about the Serbian Technical Group’s in-kind contribution,
+    signed on November 19, 2013, we were embedded in the LSST Simulations group led by Andrew
+    Connolly (University of Washington) and worked with the LSST Data Management subsystem.
+    The work packages delivered by the STG involved development of an alert simulator using
+    other components of the simulation package (opsim, catsim, stack tools, etc.). This was
+    necessary for having ‘realistic’ objects timing for generating simulated alerts. The alert
+    simulator is a part of the Rubin simulation package (github.com/lsst-sims/sims_alertsim).With
+    a new branch delivered towards the end of the last year, we added support for using MongoDB
+    as a system for a more compact and efficient way of storing alerts. We generated around
+    twenty million alerts and, though there are still some issues, we made all the products
+    available to the Alert Production team. Most of this work is recorded in the LSST JIRA
+    system.In addition, we were testing LSST Stack installations on different Linux flavors,
+    and helped student Yana Kuhanova produce a master thesis in 2016 which played a significant
+    part in a decision to adopt the DM Stack for a different instrument.Members of our team
+    were active at LSST AHM’s and PCW’s and we also organized LSST@Europe2 conference in Belgrade
+    in June 2016 (with support from LSSTC), which connected the European and US LSST communities.
+    We also acted as a proxy for LSST in a very successful EU COST action “Big data in Sky
+    and Earth Observations.”Members of our team are involved in LSST TVS and DESC Science
+    Collaborations.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SLO-UNG-S2.yaml
+++ b/docs/contribution-types/_data/software/SLO-UNG-S2.yaml
@@ -1,0 +1,51 @@
+contribution_id: SLO-UNG-S2
+title: Science Pipeline Development in the LSST TVS Science Collaboration
+country: Slovenia
+institute: UNG
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'UNG proposes to contribute 1 FTE of directable software development
+    effort preferably with specific emphasis of the contribution geared toward TVS SC, while
+    contributing this 1 FTE to the general pool of fully directable software development is
+    also an option.[a]We are open and flexible for the TVS SC to define needed software development
+    tasks, and then to carry out those tasks as an integral part of the collaboration, reporting
+    regularly on progress, taking input from the rest of the collaboration, and supporting
+    the collaboration’s members in the use of the code. We anticipate needing modest amounts
+    of local computing to support this work, and focus on using Rubin-provided user computing
+    resources as they become available to ensure the code functions at the needed scale. The
+    aforementioned local computing resources are already available at UNG, and we will work
+    to secure additional local resources if needed. The primary risk associated with this
+    work is in gaining the needed expertise in the Rubin tools and data products: to mitigate
+    this, the UNG staff will engage early with any Rubin tutorials provided, and look to be
+    active participants in events associated with the Rubin “Data Previews”, all within the
+    context of the TVS SC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SWE-STK-S1.yaml
+++ b/docs/contribution-types/_data/software/SWE-STK-S1.yaml
@@ -1,0 +1,60 @@
+contribution_id: SWE-STK-S1
+title: Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: Sweden
+institute: Stockholm
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: 'SU will contribute directable software development effort in the
+    general area of LSST DESC science analysis. We will contribute two strands of directable
+    effort: (1) computing infrastructure effort supporting areas covering data access, data
+    processing, simulation setup and management, validation and/or provenance tracking; and
+    (2) software development effort in areas requiring domain knowledge, where we have the
+    expertise to contribute to the DESC’s photometric redshift, supernovae, large scale structure
+    WGs; difference imaging and low surface brightness image processing and validation (and
+    related cross-WG activities); and observing-strategy related work. SU staff will work
+    with the DESC to define needed software development tasks, and then carry out those tasks
+    as an integral part of the collaboration, reporting regularly on progress, taking input
+    from the rest of the collaboration, and supporting the collaboration’s members in the
+    use of the code. This proposed contribution was developed in consultation with the DESC.
+    We anticipate needing modest amounts of local computing to support this work, and will
+    work to ensure that codes run on the needed scale at the primary DESC computing center
+    (currently NERSC); we may use DESC computing resources in the course of code development/testing.
+    Local computing resources are already available at the SU Physics Department through a
+    29 node cluster with 880 cores, 6128 GB memory and 462 TB storage. We will add local resources
+    if needed. The primary risk associated with this work is in gaining the needed expertise
+    in the DESC and Rubin tools and data products: to mitigate this, SU staff will engage
+    early with any Rubin and LSST DESC tutorials provided, engage with DESC Data Challenges,
+    and look to be active participants in events associated with the Rubin “Data Previews”,
+    all within the context of LSST DESC.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Photometric redshift
+  - Supernovae
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SWE-STK-S2.yaml
+++ b/docs/contribution-types/_data/software/SWE-STK-S2.yaml
@@ -1,0 +1,49 @@
+contribution_id: SWE-STK-S2
+title: Past Science Pipeline Development in the LSST Dark Energy Science Collaboration
+country: Sweden
+institute: Stockholm
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: SU staff contributed directable software development effort in the
+    general area of LSST Dark Energy science analysis, primarily within the DESC supernova
+    and observing strategy working groups. The contributed effort included substantial contributions
+    to DESC Data Challenge 2 (DC2) software development, as well as enabling contributions
+    to supernova pipeline development, observing strategy studies for transient cosmology,
+    and to transient classification software development and early classification infrastructure.
+    SU staff worked with the LSST DESC to define needed software development tasks, and then
+    carried out those tasks as an integral part of the collaboration, reporting regularly
+    on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
+    members in the use of the code. This summary of past contributions was developed in consultation
+    with DESC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Supernovae
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SWI-EPF-S1.yaml
+++ b/docs/contribution-types/_data/software/SWI-EPF-S1.yaml
@@ -1,0 +1,73 @@
+contribution_id: SWI-EPF-S1
+title: An Interactive and Dynamical Database of Strong Lensing Systems
+country: Switzerland
+institute: EPFL
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Strong Lensing Science Collaboration
+  additional_recipient_groups:
+  - LSST Dark Energy Science Collaboration
+  activity_description: 'A strong lensing database is proposed and builds on two existing
+    efforts: 1- the masterlens database of Leonidas Moustakas, who is a collaborator of EPFL
+    and a member of the Euclid strong lensing work group, 2- the EPFL database of time-delay
+    strong lenses which currently contains all known lensed quasars in addition to a number
+    of candidates found at EPFL. This database will contain at least the following: 1- all
+    known lenses, at galaxy, group, and cluster scales (along with the arcs within clusters),
+    2- positional and redshift information, 3- a classification statement, 4- the method(s)
+    used to find them, 5- lens models either from the literature or linked to the LSST modeling
+    effort, 6- deblending of the lens and source with improved photometry linked to the photo-z
+    group, 7- a catalogue of false positive in view of retraining of neural networks for improved
+    efficiency of the lens finding in LSST, 8- a catalogue of lensed transients. For each
+    object the database will query dynamically all available ancillary public data including
+    SDSS, DES, KiDS, HSC, PanSTARRS, CFIS, in addition to the MAST database and ESAsky database.
+    A query to the literature will also be included. All interactions with the database will
+    be done through APIs written, when needed, in collaboration with other DESC and SLSC infrastructures.
+    The PI’s group has the general policy to produce exclusively open source codes. In fact,
+    collaborative development with other groups working in LSST is something we would welcome.
+    The database shall be updated by any registered member with a minimum effort, for example
+    by uploading .csv files with minimum information or by editing specific fields for specific
+    lenses. EPFL will act as a moderator to make sure that only reliable entries are actually
+    recorded. This will be a long-term maintenance effort over the whole duration of the survey.
+    Specific effort will be devoted to enabling LSST strong lensing science. Links between
+    the database and the modeling tools in the consortium will be made. This is also true
+    for the deblending and photo-z works. Note that EPFL is currently designing new modeling
+    tools based on sparse regularization with wavelets and leading to improved lens/source
+    deblending as well as to exquisite source reconstruction on any grid of arbitrarily small
+    pixels. These tools will be used to feed the database with source reconstruction and source/lens
+    separation. The codes are already freely available as a lenstromy module, SLITromomy.
+    We will work along these lines for any work done in the context of the present proposal.
+    This contribution has been endorsed by the Strong Lensing Science Collaboration and the
+    Dark Energy Strong Lensing Science Collaboration.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Active galactic nuclei
+  - Astroinformatics
+  - Galaxy clusters
+  - Gravitational lensing
+  - Photometric redshift
+  - Strong gravitational lensing
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SWI-ETH-S1.yaml
+++ b/docs/contribution-types/_data/software/SWI-ETH-S1.yaml
@@ -1,0 +1,57 @@
+contribution_id: SWI-ETH-S1
+title: Science Pipeline Development in the LSST Dark Energy Survey Collaboration
+country: Switzerland
+institute: ETH
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: The ETH Cosmology group will contribute directable software development
+    effort in the area of LSST cosmological science analysis. The ETH Cosmology group will
+    first work with the Dark Energy Science Collaboration (DESC) leadership to define needed
+    software development tasks in DESC working groups and match them to the software expertise
+    available at ETH Zurich. Once these tasks have been agreed upon, a software developer
+    will be appointed at ETH Zurich and will carry out these tasks as an integral part of
+    DESC, reporting regularly on progress, taking input from the rest of the collaboration,
+    and supporting the collaboration’s members in the use of the code. Software contributions
+    to DESC working groups related to weak lensing, image simulations, photometric redshifts,
+    cosmological inference, cosmological simulation and theoretical predictions are of particular
+    interest to the ETH cosmology group, but other topics can also be discussed with the DESC
+    leadership.The ETH Cosmology group anticipates needing modest amounts of local computing
+    to support this work, and focus on using Rubin-provided user computing resources, as they
+    become available to ensure the code functions at the needed scale. In particular, the
+    developed codes will be implemented and optimised to run at NERSC. The aforementioned
+    local computing resources are already available to the cosmology group at ETH Zurich.
+    To gain the needed expertise in the DESC and Rubin tools and data products, the ETH software
+    developer will engage early with any DESC and Rubin tutorials provided, and look to be
+    active participants in events associated with the Rubin “Data Previews” and DESC data
+    challenges, all within the context of DESC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SWI-ETH-S2.yaml
+++ b/docs/contribution-types/_data/software/SWI-ETH-S2.yaml
@@ -1,0 +1,44 @@
+contribution_id: SWI-ETH-S2
+title: Covariance Estimation and Cosmology Ppieline Development in DESC
+country: Switzerland
+institute: ETH
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: UZH contributes directable software development effort to the LSST
+    DESC analyses, including the covariance estimation code TJPCov, as described in the resource
+    needs statement DESC-RN-02. UZH staff works within DESC, taking input from the Collaboration,
+    producing detailed documentation, and supporting DESC members in the use of the code as
+    needed. We use modest amounts of existing local computing to support this work as we focus
+    on using Rubin- and DESC-provided user computing resources to ensure the code functions
+    at the needed scale. We avoid risks associated with gaining the needed expertise in the
+    Rubin/DESC tools and data products as one member of our staff has already been working
+    in the pipeline scientists role.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/SZA-SAA-S2.yaml
+++ b/docs/contribution-types/_data/software/SZA-SAA-S2.yaml
@@ -1,0 +1,69 @@
+contribution_id: SZA-SAA-S2
+title: MeerKAT high-level data products and services for LSST
+country: South Africa
+institute: SAAO
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups:
+  - NOIRLab CSDC
+  activity_description: We will produce high-level data products from public MeerKAT data,
+    and any MeerKAT observing programs submitted on behalf of the LSST Galaxies SC. The MeerKAT
+    archive is making visibility data available for all projects after a 1-year proprietary
+    period, but the size and format of the visibility data (TBs per observation) makes it
+    a significant challenge to reduce these to data products suitable for scientific analysis.
+    Although the archival data will be public, the large field of view of MeerKAT means that
+    the data are extremely unlikely to be fully exploited, leaving a lot of scope for serendipitous
+    discoveries using the combination of LSST and MeerKAT data. The MeerKAT data processing
+    will be handled by South Africa, building on software pipelines that are at an advanced
+    stage of development, to produce a homogeneous contributed dataset potentially consisting
+    of thousands of square degrees of science-quality radio continuum images and catalogs
+    to the US and Chilean communities. The data processing itself will be done using high
+    performance computing facilities in South Africa, at the University of KwaZulu-Natal (for
+    prototyping) and the Centre for High Performance Computing. As MeerKAT data are lower
+    resolution (8' at L-band) than the LSST data, we will develop the tools and services to
+    optimally match them to the LSST catalogs. While the traditional 'likelihood ratio' technique
+    may work for point sources, we will need to develop new algorithms to automatically associate
+    multiple component radio sources (jets etc.) to the correct LSST counterparts (and deal
+    with the much higher source density of LSST images). This will be done under the direction
+    of the Galaxies SC, and the tools developed for this may be used as part of a broader
+    effort to optimally use similar multi-wavelength data with LSST. All the software developed
+    for this contribution will be made publicly available under free software licenses.While
+    the MeerKAT data processing challenge is large, the final MeerKAT data products will be
+    relatively small (at most 10 Tb of images and 30 Gb of catalogs, containing tens of millions
+    of objects), and Knut Olsen has confirmed that NOIRLab will host these data in the US
+    IDAC. We will provide all necessary support and documentation for this dataset and associated
+    software over the lifetime of LSST. The Galaxies Science Collaboration endorses the creation
+    of high-level data products from the MeerKAT science archive to facilitate LSST galaxy
+    evolution science.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Galaxies
+  - High performance computing
+  - Radio astronomy
+  summary: null
+  status_override: null
+  related_contribution_ids:
+  - SZA-SAA-S2

--- a/docs/contribution-types/_data/software/SZA-SAA-S3.yaml
+++ b/docs/contribution-types/_data/software/SZA-SAA-S3.yaml
@@ -1,0 +1,66 @@
+contribution_id: SZA-SAA-S3
+title: Planning and Infrastructure for the LSST Dark Energy Science Collaboration
+country: South Africa
+institute: SAAO
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: As the Rubin Observatory will detect millions of transients each night,
+    automatic photometric classification has arisen as a critical requirement for the success
+    of the survey. Dark energy constraints rely on a relatively pure sample of type Ia supernova
+    light curves. Lochner developed one of the first machine learning based supernova classification
+    codes called snmachine, in response to this requirement for the DESC supernova pipeline
+    (see key product SupernovaType on page 117 of the DESC Science Roadmap), as a software
+    development effort guided by the supernova working group. snmachine continues to be actively
+    developed by Lochner and her collaborators, is available to all DESC members and will
+    be made publicly available on publication of the final release paper. While this important
+    contribution was made when Lochner was out of South Africa and so cannot count towards
+    our in-kind contribution, it is mentioned because part of our contribution will be the
+    continued development, improvement and maintenance of snmachine in collaboration with
+    the DESC Supernova Working Group. Future improvements could include optimising the software
+    specifically for LSST data, implementing new features and algorithms and integrating snmachine
+    with broader supernova analysis pipelines.The other component of our contribution concerns
+    observing strategy infrastructure work. The observing strategy of the LSST survey impacts
+    many science cases and the Project has been engaging with the community to develop metrics
+    to help analyse different simulated observing strategies. Lochner has been co-leading
+    efforts to write these metrics for the various cosmology probes. She is also developing
+    a suite of high level tools to visualise the impact of observing strategy on cosmology
+    which will be made publicly available and will continue to serve the DESC throughout the
+    survey as observing strategy gets adjusted. The maintenance of both projects will be done
+    by Lochner and collaborators (not listed on this proposal) and so does not require additional
+    resources. The ongoing maintenance and development effort will be guided by DESC input
+    in terms of which project is higher priority and what additional features are required.DESC
+    has endorsed this contribution in an email exchange between Phil Marshall and Rachel Mandelbaum
+    (spokesperson of DESC).
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Machine learning
+  - Supernovae
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/TAI-ASI-S4.yaml
+++ b/docs/contribution-types/_data/software/TAI-ASI-S4.yaml
@@ -1,0 +1,61 @@
+contribution_id: TAI-ASI-S4
+title: Non-Directable Software Development for the Galaxy SC
+country: Taiwan
+institute: ASIAA
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Galaxies Science Collaboration
+  additional_recipient_groups: []
+  activity_description: We propose to provide a non-directable software development contribution
+    to the Galaxies SC based on our expertise and experience in scientific code development.
+    Such software development contributions will be provided through professional efforts
+    by two senior astronomers at ASIAA, Dr. Bau-Ching Hsieh (Specialist, equivalent of permanent
+    staff scientist) and Dr. Hung-Yu Jian (Support Scientist), both equipped with relevant
+    skill sets and a track record of developing software for use in extragalactic astronomy
+    and cosmology. Both Dr. Hsieh and Dr. Jian have highly advanced skills and two decades
+    of experience in fortran coding for scientific software development. Dr. Hsieh developed
+    the Direct Empirical Photometric (DEmP; Hsieh & Yee 2014, ApJ, 792, 102) code, an empirical
+    polynomial fitting machine learning algorithm for photometric-redshift estimation that
+    is designed to minimize systematic biases associated with conventional empirical fitting
+    methods. The DEmP code is one of photo-z estimation algorithms implemented into the HSC
+    pipeline (Tanaka et al. 2018, PASJ, 70, S9), and it has been extensively used for a wide
+    range of HSC extragalactic science cases. Its performance is consistently among the best
+    of the algorithms used in the HSC-SSP. We emphasize that, in its current setting, DEmP
+    meets all requirements set in “Roadmap to Photometric Redshifts for the LSST Object Catalog”
+    except for the code language (fortran).Dr. Jian has long-standing experience in writing
+    codes and developing algorithms for analyzing large data sets from the Pan-STARRS (Jian
+    et al. 2017, ApJ, 845, 74) and HSC-SSP (Jian et al. 2018, PASJ, 70, 23; Jian et al. 2020,
+    ApJ, 894, 125). Most importantly, Dr. Jain has written a cluster detection code in fortran
+    called pFOF (Probability Friends-Of-Friends; Jian et al. 2014, 788, 109) that can be applied
+    to data coming from the LSST, taking photo-z of galaxies as the main input.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Galaxies
+  - Galaxy clusters
+  - Machine learning
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-OXF-S1.yaml
+++ b/docs/contribution-types/_data/software/UKD-OXF-S1.yaml
@@ -1,0 +1,63 @@
+contribution_id: UKD-OXF-S1
+title: DESC Analysis Pipeline Development
+country: UK
+institute: Oxford
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: 'Oxford will contribute directable software development effort in
+    “catalog-to-parameters” stage of the data analysis pipeline of the Rubin DESC, which is
+    the main recipient of this contribution. This covers activities relevant to four of the
+    DESC working groups: Large-Scale Structure (LSS), Theory and Joint Probes (TJP), Weak
+    Lensing (WL) and Photometric Redshifts (PZ).These are examples of the activities for which,
+    given our expertise, we could provide a more useful contribution (with references to specific
+    deliverables and products in the DESC Science Roadmap): development of the Core Cosmology
+    Library (TJP5A), likelihood pipeline for joint analyses (TJP5B), joint pipelines with
+    CMB data (TXPipe-LSS), covariances for WL and LSS (TXCov), software for two-point statistics
+    (TXTwoPoint), the design of null tests (WLNullTest), including extensions to external
+    CMB datasets, software for astrophysical systematics (CX5), covariance matrices for joint
+    analyses (CX7), interfaces between LSS, WL and PZ (PZSummarize, PZnzSummarizers), the
+    development of algorithms to obtain optimal source and lens tomographic samples (TXSourceSelector
+    and TXLensSelector), generation of random catalogs (TXRandoms).The relevance of this proposed
+    contribution has been discussed and coordinated with the points of contact in the DESC,
+    and the example activities provided above are valuable active or anticipated deliverables
+    and products.Note that the potential PZ-related activities contained in this part of the
+    proposal are different from those described in S2. While there are obvious synergies between
+    both contributions, there is a clear division of work between the tasks of developing
+    and improving PZ algorithms (the subject of S2), and the developing of interfaces to make
+    use of PZ products in the cosmological analysis of LSS and WL data (relevant to this contribution).The
+    development and validation of these software packages will require access to HPC facilities.
+    The resources available at the Oxford Astrophysics Small Research Facility (to which we
+    have unrestricted access), as well as access to NERSC should be sufficient for this work.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Gravitational lensing
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-OXF-S4.yaml
+++ b/docs/contribution-types/_data/software/UKD-OXF-S4.yaml
@@ -1,0 +1,70 @@
+contribution_id: UKD-OXF-S4
+title: Strong Lens Discovery System and Candidate Server
+country: UK
+institute: Oxford
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Strong Lensing Science Collaboration
+  additional_recipient_groups:
+  - LSST Dark Energy Science Collaboration
+  activity_description: Oxford will contribute directable software development effort in the
+    area of the Rubin Strong Lens discovery system and infrastructure in collaboration with
+    the SLSC and DESC SL Working Group. This may include (but won’t encompass all) providing
+    the basic infrastructure for the SL discovery pipeline that connects the DM/DA to UGDP
+    image/stamp generation, explores local PSF determination and applying lens subtraction
+    methods, connects the discovery algorithms and the SL EPO (Rubin-Space Warps) platform,
+    develops and implements active learning between ML and Citizen Science, connects to multiple
+    fast modelling algorithms and then connects the resultant samples to value added databases
+    that will serve the candidates. The work also needs detailed planning and framework and
+    standards definition to achieve this to help all contributors build components that contribute
+    to the overall goal. The foreseen infrastructure will allow multiple lens finders (ML-assisted
+    or otherwise) to plug into the SL discovery system, thereby maximising the number of lenses
+    discovered. As such, the proposed work will help to deliver a system for the US/Chilean
+    Rubin community that will enable e.g. discovery, candidate ranking and follow-up prioritisation,
+    and connect the database to the alert stream to allow the identification of extragalactic
+    lensed transients a quick and fast possibility. The plan of work will be developed in
+    conjunction with the leadership for both collaborations, following priorities and gaps
+    in the infrastructure development to meet the needs of the whole Rubin SL community. We
+    are willing and happy to work with other SL infrastructure S/W teams either in place among
+    the US/Chilean communities or contributing effort via in-kinds to complete this work.We
+    will hire an experienced developer or researcher with strong computational skills who
+    will work along with the DM, EPO and SC teams to ensure that the infrastructure components
+    are effectively generated. Given the large number of cutouts that will be needed, a relationship
+    to either the US-DAC/iDAC will be developed, and accompanying infrastructure to deliver
+    these to the system and lean finders and modellers. In addition, connection of the candidate
+    servers to the alert stream via one of the alert brokers will also be needed to maximize
+    the potential to identify lensed transients from early survey data. We aim to have the
+    infrastructure in place for commissioning/early science to test and then demonstrate the
+    efficacy of the system and then improve, refine, optimise the capability as required.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Citizen science
+  - Gravitational lensing
+  - Strong gravitational lensing
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S10.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S10.yaml
@@ -1,0 +1,71 @@
+contribution_id: UKD-UKD-S10
+title: 'Science Software development: spectroscopic classification of transients and 4MOST
+  spectra'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - LSST Transients and Variable Stars Science Collaboration
+  activity_description: 'TiDES, the Time Domain Extragalactic Survey, is a survey on the 4-metre
+    Multi-Object Spectrograph Telescope (4MOST) focused on the spectroscopic follow-up of
+    Rubin Observatory LSST extragalactic optical transients. We have 250,000 fibre-hours of
+    spectroscopy time available within the TiDES survey (2% of the total 4MOST fibres). With
+    this, we will obtain (i) spectroscopic observations of 35,000 live transients to iAB=22.5,
+    and (ii) follow-up of 70,000 transient host galaxies to obtain redshift measurements for
+    photometric classification and cosmological applications. We will contribute non-directable
+    software development effort to support developing TiDES into a contributed dataset to
+    DESC and TVS. We expect there to be between 5-10 live (i < 22.5 mag) extragalactic transients
+    per 4MOST field, and we will put a fibre on all these, effectively giving a magnitude
+    limited sample. We will work closely with the DESC SN Working Group to design a selection
+    function for the LSST transient stream to optimise the type Ia SN selection (including
+    host galaxies) for cosmology. We will implement the DESC agreed strategy within the Lasair
+    broker to select SNe with high quality LSST lightcurves (or other measured characteristics
+    as desired). We will provide immediate information, to DESC and TVS (and the whole US/Chilean
+    community) onWhich objects have fibres: DESC will primarily drive the selection function.
+    As it is a magnitude limited sample we also expect all the spectra to be of interest to
+    TVS. Through Lasair, we will highlight which targets will get a spectrum. Which targets
+    have been (successfully) observed : immediate meta-data on what has been observed, signal-to-noise
+    estimate of data.Rapid estimate of redshift and type from quick-look data – available
+    to all DESC, TVS and the US/Chilean community to help decide on other triggers.Full, staged,
+    data releases of fully calibrated data, accessible through the Lasair broker.The 4MOST
+    are ESO public survey data and the raw data are public in the ESO archive immediately.
+    However these data are not in scientifically accessible or useable form without deep knowledge
+    of the pipeline, fibre allocation processes and selection function. Hence we propose this
+    as a non-directable software contribution to ensure maximum scientific exploitation of
+    the data (in line with the Handbook’s guidance on public data). The DESC and TVS endorse
+    this contribution. We note the latter is on the condition that TVS members will be kept
+    informed in a timely manner of all information relevant to these surveys. This is our
+    plan, and we are happy to accept that condition.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Spectroscopy
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids:
+  - UKD-UKD-S10

--- a/docs/contribution-types/_data/software/UKD-UKD-S11.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S11.yaml
@@ -1,0 +1,64 @@
+contribution_id: UKD-UKD-S11
+title: 'Science Software development: photometric redshift estimation and DESC related software
+  development'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - Rubin Photo-z Coordination Group
+  activity_description: This directable staff effort contribution has been developed jointly
+    with DESC. We will contribute directable software development effort to the DESC primary
+    science analysis, including but not limited to robust photo-z solutions, modelling and
+    validation of photometric redshift sample distribution, their uncertainties and how these
+    impact the DESC cosmological parameter pipelines. As directable effort within DESC we
+    will model statistical and systematic uncertainties in weak lensing and clustering signals,
+    as well as propagation of these uncertainties, especially their spatial variation across
+    the survey, into cosmological likelihoods. Joachimi and Lahav will work with relevant
+    members of the DESC Management Team and Working Group conveners to define needed software
+    development tasks, and then carry out those tasks as an integral part of the collaboration,
+    reporting regularly on progress, taking input from the rest of the collaboration, and
+    supporting the collaboration’s members in the use of the code. Joachimi and Lahav have
+    also joined Rubin’s Photometric Redshift Coordination Group and will work with this Team
+    to define additional benefits of the proposed work for LSST’s users beyond the DESC remit.
+    The work will make use of DESC’s computing resources, HPC facilities at UCL, as well as
+    UK ‘s IRIS computing dedicated to LSST (as part of the UK’s IDAC, see S3), all of which
+    are already available or are part of this in-kind proposal. Note that Joachimi’s PhD student
+    is currently road-testing GridPP facilities for DESC photo-z applications. The primary
+    risk associated with this work is the timely hiring of qualified personnel. This will
+    be mitigated by fast-tracking the funding line of this proposal if and when successful.
+    Moreover, we have ample experience recruiting highly qualified staff for infrastructure
+    work in galaxy surveys, and are currently gaining experience with COVID-era hires and
+    work models. We will also invite additional DESC management personnel onto the recruitment
+    panel.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  - Photometric redshift
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S12.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S12.yaml
@@ -1,0 +1,62 @@
+contribution_id: UKD-UKD-S12
+title: 'Science Software development: Phases C and D'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin International Program Coordinator (Software Development)
+  additional_recipient_groups: []
+  activity_description: We propose to fund a cadre of directable software developers during
+    Phases C and D of the LUSC programme, running from April 2023 to March 2027 and April
+    2027 to March 2033, respectively; although the Phase D end-date will depend on when the
+    final data release appears. These developers will be physically located in UK universities
+    but functionally embedded within an appropriate Recipient Group, usually a Science Collaboration,
+    but, potentially, part of the Rubin Observatory operations team. Our nominal plan is for
+    7 full-time positions to be funded for the four years of Phase C (i.e. 28 staff years
+    in total) and a further six staff-years during Phase D, for a total contribution of 34
+    staff-years of directable effort, although the detailed profiling of this effort can be
+    negotiated. Our proposal is that bids for developer positions are developed by UK groups
+    in conjunction with a relevant Recipient Group, and, as for our Phase B DEV WPs, are assessed
+    by a panel that combines senior UK scientists and Rubin-nominated representatives, to
+    ensure that the selected projects both make best use of existing expertise within the
+    UK community and deliver high priority outputs to the Recipient Group. These bids should
+    include consideration of maintenance of software to be delivered, for which support can
+    be provided in Phase D. Projects selected by the panel would then be included in the LUSC
+    Phase C funding proposal to be submitted to the STFC Project Peer Review Panel (PPRP)
+    some time around April 2022; this would be a submission against an agreed funding line,
+    but all project grants are peer reviewed by PPRP. This timescale then necessitates the
+    start of the proposal preparation phase in Summer 2021 - i.e. as soon as this in-kind
+    package is agreed. Computational resources will be provided through IRIS (www.iris.ac.uk),
+    a collaboration between the providers and users of computing infrastructure for STFC-funded
+    astronomy, particle and nuclear physics projects; as an IRIS member, LSST:UK makes an
+    annual bid to secure IRIS resources for the coming year.STFC will require that all funded
+    teams report to an Oversight Committee, which will monitor progress against deliverables.
+    This has begun during LUSC Phase B, with a process based around six-monthly plans, so
+    we propose that this should be the mechanism through which funded staff are redirected,
+    with new six-monthly plans agreed between the Recipient Group and the local supervisor.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S16.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S16.yaml
@@ -1,0 +1,67 @@
+contribution_id: UKD-UKD-S16
+title: Adler - Solar System Transient Classification
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Solar System Science Collaboration
+  additional_recipient_groups: []
+  activity_description: LSST will discover ~6 million new Solar System small bodies, including
+    the comet that ESA’s Comet Inceptor mission will go to (Schwamb et al. 2018, IvezÍc et
+    al. 2019). With each planetesimal receiving hundreds of observations across six filters,
+    LSST will radically transform the view of our planetary system and usher in a revolution
+    for time domain Solar System science. LSST:UK will develop Adler, an open source python-based
+    LSST Solar System transient classifier, and incorporate Adler into Lasair, the UK’s LSST
+    transient alert broker (Smith et al. 2019). Rubin Observatory’s automated routines will
+    broadcast a “transient” alert for each new, variable, or moving source. Solar System bodies
+    are always changing in their apparent brightness (possibly spanning many magnitudes) as
+    they rotate and move closer to or further away from the Sun and Earth. It will be up to
+    the Rubin user community to identify the deviations from these trends to find the interesting
+    time domain Solar System phenomena in the LSST alert stream. Lasair will contextually
+    classify LSST astrophysical alerts using Sherlock (Smith et al. 2020) but current Lasair
+    development plans are for Solar System alerts to only be stored in a database. Adler will
+    utilise either the LSST alert stream through Lasair or the prompt data products available
+    on the Rubin Science Platform (RSP) and International Data Access Centres (IDACs) to identify
+    truly changing Solar System bodies. Adler will flag potential dynamically new comets and
+    interstellar objects first entering our Solar System, identify possible planetesimal collisions,
+    break up events, or the onset of cometary activity and cometary outbursts. Adler will
+    fit rotational light curves and phase curves and identify outlying photometric points;
+    Adler will also automatically flag suitable Comet Interceptor fly-by targets, and identify
+    cometary coma/tails, through multi-aperture photometry of the alert images and source
+    extendedness. This staff effort contribution has been developed jointly with SSSC. The
+    Edinburgh postdoc will develop the core small body/comet analysis functions, and the QUB
+    software developer postdoc will focus on Lasair integration and Adler user interface and
+    infrastructure. Adler’s core functionality achieves several of the key tasks in the SSSC’s
+    Software Roadmap (Schwamb et al. 2019). The SSSC supports this contribution and welcomes
+    the flexibility to use Adler on the RSP and IDACs for an individual small body or with
+    Lasair running automatically in bulk on all incoming Solar System alerts.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Solar system astronomy
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S17.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S17.yaml
@@ -1,0 +1,64 @@
+contribution_id: UKD-UKD-S17
+title: Galaxy Clustering Infrastructure
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups:
+  - LSST Galaxies Science Collaboration
+  activity_description: 'This directable staff effort contribution has been developed jointly
+    with DESC and GSC. This contribution will focus on providing infrastructure for the treatment
+    of one of the biggest sources of systematic uncertainty for galaxy clustering: the non-cosmological
+    modulation of galaxy density caused by Galactic and observational sky contaminants (e.g.,
+    dust extinction, stars, PSF fluctuations). The proposed work is timely and impactful:
+    it will be developed in conjunction with other lensing/clustering infrastructure work
+    as part of the LSST:UK in-kind contribution, and validated on early Rubin data, addressing
+    multiple deliverables in the GSC and DESC Science Roadmaps. It will result in long term,
+    accumulating gains, affecting multiple science cases as systematics mitigation methods
+    will be needed throughout Rubin.The work will be carried out in four stages:Stage 1 (FY24-25):
+    Standard contaminant mapping and cleaning methods. LSST:UK will make a full implementation
+    of standard contaminant mapping and cleaning methods in the existing DESC analysis pipeline
+    (TXPipe). This includes mapping of survey depth and contaminant moments, linear deprojection,
+    random catalog generation.Stage 2 (FY25-26): Source injection infrastructure. LSST:UK
+    will implement Source Injection (SI) methods, adding mock objects to images and reprocessing
+    them to characterise system responses. LSST:UK will implement the significant software
+    infrastructure to inject and process fake sources, and to process the resulting catalogs
+    with TXPipe.Stage 3 (FY26-27): Optimal data cuts and robust clustering measurements. LSST:UK
+    will develop software to produce robust GC measurements using SI, in order to recommend
+    optimal quality and sky cuts, produce catalog weights and cleaned overdensity maps, and
+    compute diagnostics (e.g. signal-systematic correlations).Stage 4 (FY27): Clustering data
+    products from DR1 and DR2. LSST:UK will apply the new infrastructure to DR1 and DR2 data,
+    to test and compare standard SI decontamination methods. LSST:UK will generate vital products
+    for any clustering measurements made by the DESC and the GSC: random catalogs, masks,
+    systematic maps.'
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S6.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S6.yaml
@@ -1,0 +1,66 @@
+contribution_id: UKD-UKD-S6
+title: 'Science Software development: Low surface brightness science'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: Rubin Algorithms & Pipelines Team
+  additional_recipient_groups:
+  - LSST Galaxies Science Collaboration
+  activity_description: The LSB Universe – the regime that is inaccessible in past wide-area
+    surveys – hosts virtually all of LSST’s extra-galactic discovery space. However, LSST’s
+    ability to access this revolutionary domain depends on the sky-subtraction in the DM pipeline
+    preserving LSB flux in LSST images. We will contribute directable pipeline development
+    to produce sky-background modelling and subtraction that preserves LSB flux, which is
+    essential for LSST Galaxies science. The immediate recipient is the Rubin Algorithms and
+    Pipelines team and the eventual beneficiary is the Galaxies Science Collaboration (GSC).
+    We have already been working on this project, in a directable fashion, with the DM team
+    (Kelvin/Al-Sayyad/Lupton/Reed) since March 20. We have developed quality-assurance metrics,
+    in the form of surface-brightness/magnitude deficits, to quantify how the pipeline handles
+    LSB flux. As a proof of concept, injection of fake single-Sersic sources into coadded
+    imaging, from the continuously re-reduced COSMOS tract 9813, has revealed potentially
+    significant sky over-subtraction at flux levels fainter than ~26 mag arcsec-2 around large
+    objects (>8 arcsec), with a flux-loss ratio of >15 percent in the worst cases. This relatively
+    aggressive sky-subtraction ensures that LSB flux does not connect objects and confuse
+    de-blenders, making it ideal for weak-lensing science. However, it compromises the majority
+    of Galaxies science. A bifurcation of the pipeline appears necessary to satisfy both communities.
+    Ongoing testing in collaboration with the DM team will repeat these analyses for a more
+    realistic scenario, injecting fake sources at the visit level and propagating those images
+    through to final coaddition. The broad plan is to explore intermediate points in the DM
+    pipeline, where the sky-subtraction is not as aggressive, as a starting point to developing
+    sky-background modelling and subtraction that preserves LSB flux. We will continue to
+    work closely with the DM team to identify future development tasks and perform these as
+    an integral part of the GSC, taking input from members and reporting regularly on progress
+    in telecons and via interaction on Slack. We are using the Rubin Science Platform (RSP)
+    to access and analyze pre- and post-model injection outputs from the DM pipeline, since
+    the RSP computing architecture is built specifically for the Project, and using local
+    resources to interpret the results. We do not anticipate a change in our resource needs.
+    The primary risk is gaining an understanding of the DM pipeline architecture. However,
+    our close and ongoing interaction with the DM team mitigates this.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astronomy software
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S8.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S8.yaml
@@ -1,0 +1,53 @@
+contribution_id: UKD-UKD-S8
+title: 'Science Software development: DESC operations'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Directable SW dev
+  primary_recipient_group: LSST Dark Energy Science Collaboration
+  additional_recipient_groups: []
+  activity_description: Zuntz is designing and implementing the catalogue-to-cosmology pipeline,
+    TXPipe, for the weak lensing and large-scale structure joint analysis, implementing (at
+    LSST scale) algorithms for data reduction and analysis from DM catalogues into two-point
+    measurements and other summary statistics. This has been identified as a key pipeline
+    in the DESC Science Roadmap. He has also written and is managing the infrastructure framework,
+    Ceci, for running the collected complete pipeline. This software was/is all written specifically
+    for the DESC.Perry will manage simulation data generation, storage, and analysis as a
+    key part of the data challenge simulation process. In both cases this activity is directable
+    by the collaboration; Zuntz reports to the analysis coordinator, providing quarterly reports
+    and annual plans, and Perry ultimately to the computing coordinator, with day-to-day coordination
+    by Zuntz. Computing for Zuntz's work on the lensing/clustering pipeline is available from
+    NERSC via DESC's allocation. Computing for Perry's work on the UK Grid is provided by
+    an existing GridPP grant. All software developed by the team will be public, in accordance
+    with the proposed DESC software policy.This proposal has been developed in consultation
+    with DESC. The past contribution FY19-FY20 has been endorsed by DESC.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Cosmology
+  - Galaxy clusters
+  - Gravitational lensing
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/_data/software/UKD-UKD-S9.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S9.yaml
@@ -1,0 +1,67 @@
+contribution_id: UKD-UKD-S9
+title: 'Science Software development: Cross-matching'
+country: UK
+institute: LSST:UK
+form_data:
+  category: Non-directable SW dev
+  primary_recipient_group: LSST Transients and Variable Stars Science Collaboration
+  additional_recipient_groups:
+  - LSST Stars Milky Way and Local Volume Science Collaboration
+  activity_description: The depth of the LSST survey represents an almost unique challenge
+    to attempts to cross-match the catalogues to other surveys, because of the combination
+    of depth and point-spread function. The LSST is deeper than any ground-based survey to
+    date, yet the Rubin observatory is still limited by ground-based seeing. As a result the
+    number of stars per point-spread function is very large. At the most basic level this
+    means that traditional matching by (say) a 2” proximity match will get confused. As an
+    example, roughly half the galactic plane within -90 < l < 90 and |b|< 10 reaches a density
+    of sources such that in a single visit that there will (on average) be one random match
+    per 2” circle. Hence as the survey becomes deeper this problem will spread out of the
+    plane until by full depth it is even having a small effect on high latitude fields. This
+    problem can be overcome by using the uncertainties in the astrometry to show whether sources
+    are truly co-incident, but requires a fully Bayesian approach which takes into account
+    the local stellar density (see Sutherland & Saunders 1992MNRAS.259..413S). However, there
+    is also a second more subtle problem which affects the astrometric uncertainties and means
+    one cannot simply use the uncertainties from image centroiding. This is that the stellar
+    densities at magnitudes below the survey detection limit are so high that undetected stars
+    affect the centroids. These effects are significant, but can be modelled (Wilson & Naylor
+    2017MNRAS.468.2517W). Finally, photometric information can also be used to assess whether
+    a match is likely (Wilson & Naylor 2018MNRAS.473.5570W). This proposal is to make cross-matches
+    between the LSST and the VISTA, VPHAS, WISE and Spitzer surveys using these up-to-date
+    techniques available to astronomers both as a software package and tables of matches.
+    The work is endorsed by the TVS SC, hence we are proposing this as non-directable effort.
+    An endorsement has been requested from SMWLV, and we have engaged with the Rubin Crowded
+    Field Coordination Group.We have LSST:UK funding in place to write the software, validate
+    it against Hyper Suprime-Cam data and integrate it into the UK IDAC. During operations
+    the software could be run either on the UK IDAC, or be part of the standard release pipeline,
+    producing cross-match tables between the entirety of the LSST and the other surveys. The
+    compute time required to build the tables will be provided through the UK IDAC computing
+    resource as described in S3.
+  submitted: false
+  email: null
+  submitter_name: null
+  target_audience: null
+  software_name: null
+  version: null
+  software_url: null
+  documentation: null
+  verification_testing: null
+  sharing_of_software: null
+  publications: null
+  acknowledgements: null
+  support: null
+  maintenance_plan: null
+  maintenance_notes: null
+  further_development: null
+  other_feedback: null
+  uat_category: null
+  uat_concepts: null
+  associated_dataset: null
+curated:
+  uat_keywords:
+  - Astroinformatics
+  - Astronomy software
+  - Time domain astronomy
+  - Transient detection
+  summary: null
+  status_override: null
+  related_contribution_ids: []

--- a/docs/contribution-types/contributed-datasets.rst
+++ b/docs/contribution-types/contributed-datasets.rst
@@ -190,6 +190,8 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
 
       {% for ds in datasets %}
       {% if ds.status == 'available' %}
+      .. _ds-cid-{{ ds.cid_slug }}:
+
       .. grid-item-card:: {{ ds.title }}
           :class-item: ikc-card {{ ds.filter_tokens }}
 
@@ -219,6 +221,8 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
           +++
           :bdg-success:`Available`
       {% else %}
+      .. _ds-cid-{{ ds.cid_slug }}:
+
       .. grid-item-card:: {{ ds.title }}
           :class-item: ikc-card {{ ds.filter_tokens }}
 

--- a/docs/contribution-types/contributed-software.rst
+++ b/docs/contribution-types/contributed-software.rst
@@ -1,0 +1,220 @@
+######################
+Contributed Software
+######################
+
+The Vera C. Rubin Observatory In-Kind Program includes contributed software: directable and non-directable software-development effort that international partners contribute to Rubin teams and LSST Science Collaborations.
+This page lists all current software-development contributions. General pool contributions -- directable effort offered without a recipient defined ahead of time -- are listed on the :doc:`general-pool` page instead.
+
+Use the filters or the table below to browse by category, science keyword, or recipient group.
+Each entry starts with the basics from the original proposal; cards marked *Delivered* have a full team-submitted record on file, and cards marked *Pending* are still awaiting that submission.
+Some software contributions also produce a dataset -- where that's the case, the card links to the matching entry on the :doc:`contributed-datasets` page.
+
+Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have any questions about contributed software.
+
+.. jinja:: contributed_software
+
+   .. raw:: html
+
+      <style>
+        .ikc-filterbar { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem; }
+        .ikc-filterbar label { font-size: 0.9em; }
+        .ikc-sw-table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
+        .ikc-sw-table th, .ikc-sw-table td { text-align: left; padding: 0.5em 0.75em; border-bottom: 1px solid #ddd; }
+        .ikc-sw-table th { cursor: pointer; user-select: none; }
+        .ikc-badge { display: inline-block; padding: 0.15em 0.6em; border-radius: 1em; font-size: 0.85em; }
+        .ikc-badge-success { background: #d9f2e3; color: #1a5c33; }
+        .ikc-badge-muted { background: #e6e6e6; color: #555; }
+        .ikc-actionbar { display: flex; flex-wrap: wrap; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+        .ikc-actionbar input[type="text"] { flex: 1; min-width: 220px; padding: 0.4em 0.6em; border: 1px solid #999; border-radius: 0.3em; font-size: 0.9em; }
+        .ikc-title-link { color: inherit; text-decoration: none; cursor: pointer; background: none; border: none; padding: 0; font: inherit; text-align: left; }
+        .ikc-title-link:hover { text-decoration: underline; }
+        .ikc-sw-card.ikc-highlight .sd-card { outline: 3px solid #1a5c33; outline-offset: 2px; transition: outline-color 1.2s ease; }
+        .ikc-desc { -webkit-line-clamp: 3; display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0.4em; }
+        .ikc-desc.ikc-expanded { -webkit-line-clamp: unset; display: block; overflow: visible; }
+        .ikc-expand-btn { border: none; background: none; color: #1a5c33; font-size: 0.85em; padding: 0; cursor: pointer; margin-bottom: 0.6em; }
+        .ikc-also-see { display: block; background: #e6e6e6; color: #333; font-size: 0.85em; padding: 0.3em 0.7em; border-radius: 1em; margin-top: 0.5em; text-decoration: none; }
+        .ikc-also-see:hover { background: #d9d9d9; }
+      </style>
+
+      <div class="ikc-filterbar">
+        <label>Category
+          <select id="ikc-sw-filter-cat">
+            <option value="">All</option>
+            {% for v in all_categories %}<option value="cat-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>UAT keyword
+          <select id="ikc-sw-filter-uat">
+            <option value="">All</option>
+            {% for v in all_uat %}<option value="uat-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Primary recipient
+          <select id="ikc-sw-filter-recipient">
+            <option value="">All</option>
+            {% for v in all_recipients %}<option value="recipient-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Status
+          <select id="ikc-sw-filter-status">
+            <option value="">All</option>
+            <option value="status-delivered">Delivered</option>
+            <option value="status-pending">Pending</option>
+          </select>
+        </label>
+      </div>
+
+      <div class="ikc-actionbar">
+        <input type="text" id="ikc-sw-search" placeholder="Search title, description, keywords...">
+      </div>
+
+      <table class="ikc-sw-table" id="ikc-sw-table">
+        <thead>
+          <tr>
+            <th data-sort="title">Software</th>
+            <th data-sort="category">Category</th>
+            <th data-sort="recipient">Primary recipient</th>
+            <th data-sort="status">Status</th>
+            <th data-sort="updated">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in software %}
+          <tr class="ikc-row" data-tokens="{{ item.filter_tokens }}"
+              data-title="{{ item.title }}"
+              data-category="{{ item.form_data.category or '' }}"
+              data-recipient="{{ item.form_data.primary_recipient_group or '' }}"
+              data-status="{{ item.status }}"
+              data-updated="{{ item.last_updated or '' }}">
+            <td><button type="button" class="ikc-title-link" data-cid="{{ item.cid_slug }}">{{ item.title }} ({{ item.contribution_id }})</button></td>
+            <td>{{ item.form_data.category or 'TBD' }}</td>
+            <td>{{ item.form_data.primary_recipient_group or 'TBD' }}</td>
+            <td>{% if item.status == 'delivered' %}<span class="ikc-badge ikc-badge-success">Delivered</span>{% else %}<span class="ikc-badge ikc-badge-muted">Pending</span>{% endif %}</td>
+            <td>{{ item.last_updated or 'unknown' }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <script>
+      (function () {
+        var SEARCH_INDEX = {{ search_index_json }};
+        var CID_RE = /cid-([a-z0-9-]+)/;
+
+        function matchesSearch(tokens) {
+          var query = document.getElementById('ikc-sw-search').value.trim().toLowerCase();
+          if (!query) { return true; }
+          var m = CID_RE.exec(tokens);
+          var text = m ? (SEARCH_INDEX[m[1]] || '') : '';
+          return text.indexOf(query) !== -1;
+        }
+
+        function setVisible(el, visible) {
+          if (visible) {
+            el.style.removeProperty('display');
+          } else {
+            el.style.setProperty('display', 'none', 'important');
+          }
+        }
+
+        function applyFilters() {
+          var cat = document.getElementById('ikc-sw-filter-cat').value;
+          var uat = document.getElementById('ikc-sw-filter-uat').value;
+          var recipient = document.getElementById('ikc-sw-filter-recipient').value;
+          var status = document.getElementById('ikc-sw-filter-status').value;
+          var filters = [cat, uat, recipient, status].filter(Boolean);
+          document.querySelectorAll('#ikc-sw-table .ikc-row').forEach(function (row) {
+            var tokenStr = row.getAttribute('data-tokens');
+            var tokens = ' ' + tokenStr + ' ';
+            var visible = filters.every(function (f) { return tokens.indexOf(' ' + f + ' ') !== -1; })
+              && matchesSearch(tokenStr);
+            setVisible(row, visible);
+          });
+          document.querySelectorAll('.ikc-sw-card').forEach(function (card) {
+            var tokenStr = card.className;
+            var tokens = ' ' + tokenStr + ' ';
+            var visible = filters.every(function (f) { return tokens.indexOf(' ' + f + ' ') !== -1; })
+              && matchesSearch(tokenStr);
+            setVisible(card, visible);
+          });
+        }
+        ['ikc-sw-filter-cat', 'ikc-sw-filter-uat', 'ikc-sw-filter-recipient', 'ikc-sw-filter-status'].forEach(function (id) {
+          var el = document.getElementById(id);
+          if (el) el.addEventListener('change', applyFilters);
+        });
+        var searchInput = document.getElementById('ikc-sw-search');
+        if (searchInput) { searchInput.addEventListener('input', applyFilters); }
+
+        document.querySelectorAll('.ikc-title-link').forEach(function (link) {
+          link.addEventListener('click', function () {
+            var cid = link.getAttribute('data-cid');
+            var card = document.querySelector('.ikc-sw-card.cid-' + cid);
+            if (!card) { return; }
+            card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            card.classList.add('ikc-highlight');
+            setTimeout(function () { card.classList.remove('ikc-highlight'); }, 1500);
+          });
+        });
+
+        document.querySelectorAll('.ikc-expand-btn').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var desc = btn.previousElementSibling;
+            var expanded = desc.classList.toggle('ikc-expanded');
+            btn.textContent = expanded
+              ? btn.getAttribute('data-collapse-label')
+              : btn.getAttribute('data-expand-label');
+          });
+        });
+
+        var sortState = {};
+        document.querySelectorAll('#ikc-sw-table th[data-sort]').forEach(function (th) {
+          th.addEventListener('click', function () {
+            var key = th.getAttribute('data-sort');
+            var tbody = document.querySelector('#ikc-sw-table tbody');
+            var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+            var asc = !sortState[key];
+            sortState = {};
+            sortState[key] = asc;
+            rows.sort(function (a, b) {
+              var av = a.getAttribute('data-' + key) || '';
+              var bv = b.getAttribute('data-' + key) || '';
+              return asc ? av.localeCompare(bv) : bv.localeCompare(av);
+            });
+            rows.forEach(function (r) { tbody.appendChild(r); });
+          });
+        });
+      })();
+      </script>
+
+   .. grid:: 1 1 2 2
+      :gutter: 2
+
+      {% for item in software %}
+      .. _sw-cid-{{ item.cid_slug }}:
+
+      .. grid-item-card:: {{ item.title }}
+          :class-item: ikc-sw-card ikc-card {{ item.filter_tokens }}
+
+          {{ item.contribution_id }}
+          ^^^
+          {% for kw in item.uat_keywords %}:bdg-light:`{{ kw }}` {% endfor %}
+
+          **Primary recipient:** {{ item.form_data.primary_recipient_group or 'TBD' }}
+
+          **Additional recipients:** {{ (item.form_data.additional_recipient_groups or []) | join(', ') or 'None' }}
+
+          .. raw:: html
+
+             <div class="ikc-desc">{{ item.form_data.activity_description or 'TBD' }}</div>
+             <button type="button" class="ikc-expand-btn" data-expand-label="Show more" data-collapse-label="Show less">Show more</button>
+
+          {% for rel in item.related %}
+          {% if rel.page_url %}
+          `Also see: {{ rel.title }} ({{ rel.contribution_id }}) → <{{ rel.page_url }}#ds-cid-{{ rel.slug }}>`_
+          {% endif %}
+          {% endfor %}
+
+          *Updated: {{ item.last_updated or 'unknown' }}*
+          +++
+          {% if item.status == 'delivered' %}:bdg-success:`Delivered`{% else %}:bdg-muted:`Pending`{% endif %}
+      {% endfor %}

--- a/docs/contribution-types/contributed-software.rst
+++ b/docs/contribution-types/contributed-software.rst
@@ -203,6 +203,8 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
 
           **Additional recipients:** {{ (item.form_data.additional_recipient_groups or []) | join(', ') or 'None' }}
 
+          {% if item.form_data.software_name %}**Software:** {{ item.form_data.software_name }}{% endif %}
+
           .. raw:: html
 
              <div class="ikc-desc">{{ item.form_data.activity_description or 'TBD' }}</div>

--- a/docs/contribution-types/contributed-software.rst
+++ b/docs/contribution-types/contributed-software.rst
@@ -32,7 +32,7 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
         .ikc-desc { -webkit-line-clamp: 3; display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0.4em; }
         .ikc-desc.ikc-expanded { -webkit-line-clamp: unset; display: block; overflow: visible; }
         .ikc-expand-btn { border: none; background: none; color: #1a5c33; font-size: 0.85em; padding: 0; cursor: pointer; margin-bottom: 0.6em; }
-        .ikc-also-see { display: block; background: #e6e6e6; color: #333; font-size: 0.85em; padding: 0.3em 0.7em; border-radius: 1em; margin-top: 0.5em; text-decoration: none; }
+        .ikc-also-see { display: inline-block; background: #e6e6e6; color: #333; font-size: 0.85em; padding: 0.3em 0.8em; border-radius: 1em; margin-top: 0.5em; text-decoration: none; }
         .ikc-also-see:hover { background: #d9d9d9; }
       </style>
 
@@ -212,7 +212,12 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
 
           {% for rel in item.related %}
           {% if rel.page_url %}
-          `Also see: {{ rel.title }} ({{ rel.contribution_id }}) → <{{ rel.page_url }}#ds-cid-{{ rel.slug }}>`_
+          {% set rel_kind = 'dataset' if 'datasets' in rel.page_url else 'facility' %}
+
+          .. raw:: html
+
+             <a class="ikc-also-see" href="{{ rel.page_url }}#ds-cid-{{ rel.slug }}">Also see: {{ rel_kind }} ({{ rel.contribution_id }}) &rarr;</a>
+
           {% endif %}
           {% endfor %}
 

--- a/docs/contribution-types/index.rst
+++ b/docs/contribution-types/index.rst
@@ -14,6 +14,7 @@ Contribution Types
 
    general-pool
    contributed-datasets
+   contributed-software
    contributed-telescope
    contributed-resources
 

--- a/scripts/sync_software_contributions.py
+++ b/scripts/sync_software_contributions.py
@@ -136,41 +136,73 @@ def load_contributions(path):
 
 
 # --- read the shared Google Form export ---------------------------------
+#
+# The form asks "Maintenance Plan & Updates" and "Describe any planned
+# updates or maintenance" TWICE -- once for the software section (columns
+# 17-18) and again for the dataset section (columns 34-35). csv.DictReader
+# keys rows by header name, so it silently collapses each duplicate pair to
+# whichever column comes last, which quietly overwrote the software-specific
+# answer with the dataset one. Reading by fixed position instead of by
+# header name sidesteps that entirely.
+FORM_COLUMNS = [
+    "timestamp", "email", "contribution_id", "submitter_name", "target_audience",
+    "software_name", "contribution_summary", "version", "deliverable_type",
+    "software_url", "documentation", "verification_testing", "sharing_of_software",
+    "publications", "acknowledgements", "support",
+    "sw_maintenance_plan", "sw_maintenance_notes", "further_development", "other_feedback",
+    "data_products_expected", "data_type", "data_volume", "data_schema_link",
+    "hosting_location", "access_url", "access_mechanisms", "authentication",
+    "generation_methods", "validation_limitations", "tutorials_docs", "support_channel",
+    "citation", "ds_maintenance_plan", "ds_maintenance_notes", "final_report",
+    "uat_category", "uat_concepts",
+]
+
 
 def load_form_responses(path):
-    """Return the latest Software-deliverable response per Contribution ID."""
+    """Return the latest Software-deliverable response per Contribution ID,
+    plus the set of Contribution IDs among *those Software-labeled* responses
+    (for the unmatched-response warning in sync() -- Datasets-labeled
+    responses are a different page's concern and are never expected to
+    appear in this spreadsheet, so they're excluded from that check)."""
     if path is None:
-        return {}
+        return {}, set()
     with open(path, newline="", encoding="utf-8") as f:
-        rows = list(csv.DictReader(f))
+        rows = list(csv.reader(f))
+    header = rows[0]
+    if len(header) != len(FORM_COLUMNS):
+        raise ValueError(
+            f"form CSV has {len(header)} columns, expected {len(FORM_COLUMNS)} -- "
+            "the form likely changed; update FORM_COLUMNS to match before re-running."
+        )
     responses = {}
-    for row in rows:
-        if row.get("Contribution deliverable type", "").strip() != "Software":
+    software_ids = set()
+    for raw in rows[1:]:
+        row = dict(zip(FORM_COLUMNS, raw))
+        cid = row["contribution_id"].strip()
+        if not cid or row["deliverable_type"].strip() != "Software":
             continue
-        cid = row.get("Contribution ID", "").strip()
-        if not cid:
-            continue
+        software_ids.add(cid)
         # Later rows (later timestamps) win if a team resubmits.
         responses[cid] = row
-    return responses
+    return responses, software_ids
 
 
 DATASET_FIELD_MAP = {
-    "Data Type": "data_type",
-    "Total Data Volume & Scale": "data_volume",
-    "Data Schema / Data Dictionary Link": "data_schema_link",
-    "Hosting Location": "hosting_location",
-    "Access URL or DOI": "access_url",
-    "Access Mechanisms": "access_mechanisms",
-    "Authentication & Access Restrictions": "authentication",
-    "Generation Methods": "generation_methods",
-    "Validation Status & Known Limitations": "validation_limitations",
-    "Tutorials, Examples, & Documentation": "tutorials_docs",
-    "Community Support Channel": "support_channel",
-    "Citation and Acknowledgment": "citation",
-    "Maintenance Plan & Updates": "maintenance_plan",
-    "Describe any planned updates or maintenance": "maintenance_notes",
-    "Final report": "final_report",
+    "data_type": "data_type",
+    "data_volume": "data_volume",
+    "data_schema_link": "data_schema_link",
+    "hosting_location": "hosting_location",
+    "access_url": "access_url",
+    "access_mechanisms": "access_mechanisms",
+    "authentication": "authentication",
+    "generation_methods": "generation_methods",
+    "validation_limitations": "validation_limitations",
+    "tutorials_docs": "tutorials_docs",
+    "support_channel": "support_channel",
+    "citation": "citation",
+    "ds_maintenance_plan": "maintenance_plan",
+    "ds_maintenance_notes": "maintenance_notes",
+    "final_report": "final_report",
 }
 LIST_VALUED_DATASET_FIELDS = {"data_type", "access_mechanisms"}
 
@@ -180,14 +212,9 @@ def split_list(value):
 
 
 def build_associated_dataset(response):
-    if normalize_ws(response.get("Were any data products expected as part of this contribution?", "")) != "Yes":
+    if normalize_ws(response.get("data_products_expected", "")) != "Yes":
         return None
     out = {"submitted": True}
-    # DATASET_FIELD_MAP has two Google Form columns sharing the label
-    # "Maintenance Plan & Updates" / "Describe any planned updates or
-    # maintenance" with the software section above -- DictReader only keeps
-    # the last column of a repeated header, which for this form is the
-    # dataset-section instance, so this direct lookup is correct here.
     for form_col, out_key in DATASET_FIELD_MAP.items():
         value = normalize_ws(response.get(form_col))
         if out_key in LIST_VALUED_DATASET_FIELDS:
@@ -199,25 +226,25 @@ def build_associated_dataset(response):
 
 def merge_form_response(record, response):
     record["submitted"] = True
-    record["email"] = normalize_ws(response.get("Email Address"))
-    record["submitter_name"] = normalize_ws(response.get("Name (first last)"))
-    record["target_audience"] = normalize_ws(response.get("Target Audience"))
-    record["software_name"] = normalize_ws(response.get("Software/Package/Dataset Name"))
-    record["version"] = normalize_ws(response.get("Version of the Software/Package/Dataset "))
-    record["software_url"] = normalize_ws(response.get("Software URL"))
-    record["documentation"] = normalize_ws(response.get("Documentation"))
-    record["verification_testing"] = normalize_ws(response.get("Verification and testing"))
-    record["sharing_of_software"] = normalize_ws(response.get("Sharing of the software"))
-    record["publications"] = normalize_ws(response.get("Publications"))
-    record["acknowledgements"] = normalize_ws(response.get("Acknowledgements text"))
-    record["support"] = normalize_ws(response.get("Support"))
-    record["maintenance_plan"] = normalize_ws(response.get("Maintenance Plan & Updates"))
-    record["maintenance_notes"] = normalize_ws(response.get("Describe any planned updates or maintenance"))
-    record["further_development"] = normalize_ws(response.get("Further development"))
-    record["other_feedback"] = normalize_ws(response.get("Any other feedback"))
-    uat_category = split_list(response.get("Unified Astronomy Thesaurus (UAT) Category"))
+    record["email"] = normalize_ws(response.get("email"))
+    record["submitter_name"] = normalize_ws(response.get("submitter_name"))
+    record["target_audience"] = normalize_ws(response.get("target_audience"))
+    record["software_name"] = normalize_ws(response.get("software_name"))
+    record["version"] = normalize_ws(response.get("version"))
+    record["software_url"] = normalize_ws(response.get("software_url"))
+    record["documentation"] = normalize_ws(response.get("documentation"))
+    record["verification_testing"] = normalize_ws(response.get("verification_testing"))
+    record["sharing_of_software"] = normalize_ws(response.get("sharing_of_software"))
+    record["publications"] = normalize_ws(response.get("publications"))
+    record["acknowledgements"] = normalize_ws(response.get("acknowledgements"))
+    record["support"] = normalize_ws(response.get("support"))
+    record["maintenance_plan"] = normalize_ws(response.get("sw_maintenance_plan"))
+    record["maintenance_notes"] = normalize_ws(response.get("sw_maintenance_notes"))
+    record["further_development"] = normalize_ws(response.get("further_development"))
+    record["other_feedback"] = normalize_ws(response.get("other_feedback"))
+    uat_category = split_list(response.get("uat_category"))
     record["uat_category"] = uat_category or None
-    record["uat_concepts"] = normalize_ws(response.get("Specific UAT Concepts"))
+    record["uat_concepts"] = normalize_ws(response.get("uat_concepts"))
     record["associated_dataset"] = build_associated_dataset(response)
 
 
@@ -281,7 +308,13 @@ def write_yaml(path, data):
 def sync(contributions_csv, form_responses_csv):
     SOFTWARE_DIR.mkdir(parents=True, exist_ok=True)
     contributions = load_contributions(contributions_csv)
-    form_responses = load_form_responses(form_responses_csv)
+    form_responses, form_response_ids = load_form_responses(form_responses_csv)
+
+    unmatched = sorted(form_response_ids - set(contributions))
+    if unmatched:
+        print(f"WARNING: {len(unmatched)} Software-labeled form response(s) reference a "
+              f"Contribution ID not found in the spreadsheet (typo, or a General Pool "
+              f"contribution that's out of scope here) -- skipped: {', '.join(unmatched)}")
 
     dataset_titles = collect_existing_ids(DATASETS_DIR)
     telescope_titles = collect_existing_ids(TELESCOPES_DIR)

--- a/scripts/sync_software_contributions.py
+++ b/scripts/sync_software_contributions.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Sync docs/contribution-types/_data/software/*.yaml from source CSVs.
+
+Two inputs:
+  --contributions   the proposal-spreadsheet export (one row per contribution;
+                     columns: Country, Institute, ID, Contribution Title,
+                     Scraped Recipient Group, SOW, Timeline, Category,
+                     Recipient Group(s), Primary Recipient Group,
+                     Activity Description)
+  --form-responses  the "In-kind Contribution Resources" Google Form export,
+                     shared with the Datasets page's intake. Only rows whose
+                     "Contribution deliverable type" is Software are used
+                     here; rows also answering "Yes" to data products get an
+                     `associated_dataset` block and, if no Datasets record
+                     exists yet for that ID, a draft one is written too.
+
+Safe to re-run: `form_data` is fully regenerated every run (it's owned by
+this script); `curated` is written once on first creation and never touched
+again on subsequent runs, exactly like the Datasets page's own split.
+
+General Pool contributions (Category "4.1 - General pooled SW dev") are
+skipped entirely -- those already have their own page.
+"""
+import argparse
+import csv
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOFTWARE_DIR = REPO_ROOT / "docs" / "contribution-types" / "_data" / "software"
+DATASETS_DIR = REPO_ROOT / "docs" / "contribution-types" / "_data" / "datasets"
+TELESCOPES_DIR = REPO_ROOT / "docs" / "contribution-types" / "_data" / "telescopes"
+
+CATEGORY_LABELS = {
+    "4.2": "Directable SW dev",
+    "4.3": "Non-directable SW dev",
+}
+
+# --- UAT keyword guesser -----------------------------------------------
+# Used only until a record's real team-submission form response arrives
+# with actual "UAT Category"/"Specific UAT Concepts" answers -- this is a
+# coarse, reviewable starting guess, not a substitute for real curation.
+RECIPIENT_KEYWORDS = {
+    "dark energy": ["Cosmology"],
+    "galaxies": ["Galaxies"],
+    "transients and variable stars": ["Time domain astronomy", "Transient detection"],
+    "agn": ["Active galactic nuclei"],
+    "solar system": ["Solar system astronomy"],
+    "strong lensing": ["Strong gravitational lensing", "Gravitational lensing"],
+    "stars milky way": ["Variable stars"],
+    "crowded field": ["Stellar photometry"],
+}
+TEXT_KEYWORDS = {
+    "photo-z": ["Photometric redshift"],
+    "photometric redshift": ["Photometric redshift"],
+    "lensing": ["Gravitational lensing"],
+    "machine learning": ["Machine learning"],
+    "deep learning": ["Deep learning", "Machine learning"],
+    "spectroscop": ["Spectroscopy"],
+    "transient": ["Transient detection", "Time domain astronomy"],
+    "variable star": ["Variable stars"],
+    "supernova": ["Supernovae"],
+    "quasar": ["Active galactic nuclei"],
+    " agn": ["Active galactic nuclei"],
+    "cluster": ["Galaxy clusters"],
+    "radio": ["Radio astronomy"],
+    "pipeline": ["Astronomy software"],
+    "software": ["Astronomy software"],
+    "catalog": ["Astroinformatics"],
+    "database": ["Astroinformatics"],
+    "citizen science": ["Citizen science"],
+    "high performance comput": ["High performance computing"],
+    "visualiz": ["Data visualization"],
+    "asteroid": ["Solar system astronomy"],
+    "microlensing": ["Gravitational lensing"],
+}
+
+
+def guess_uat_keywords(title, description, primary_recipient):
+    text = f"{title} {description}".lower()
+    pr = (primary_recipient or "").lower()
+    tags = set()
+    for key, vals in RECIPIENT_KEYWORDS.items():
+        if key in pr:
+            tags.update(vals)
+    for key, vals in TEXT_KEYWORDS.items():
+        if key in text:
+            tags.update(vals)
+    if not tags:
+        tags.add("Astronomy software")
+    return sorted(tags)
+
+
+def normalize_ws(value):
+    if value is None:
+        return None
+    cleaned = " ".join(value.replace("\xa0", " ").split())
+    return cleaned or None
+
+
+def slugify(value):
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+# --- read the proposal-spreadsheet CSV ----------------------------------
+
+def load_contributions(path):
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    header = rows[2]
+    assert header[2] == "ID", f"unexpected header row: {header}"
+    records = {}
+    for row in rows[3:]:
+        if not row[2].strip():
+            continue
+        category_code = row[7].strip().split(" ", 1)[0]
+        if category_code == "4.1":
+            continue  # General Pool -- has its own page, not imported here
+        recipients = [r.strip() for r in row[8].split(",") if r.strip()]
+        primary = row[9].strip()
+        additional = [r for r in recipients if r != primary]
+        cid = row[2].strip()
+        records[cid] = {
+            "contribution_id": cid,
+            "title": normalize_ws(row[3]),
+            "country": row[0].strip(),
+            "institute": row[1].strip(),
+            "category": CATEGORY_LABELS.get(category_code, row[7].strip()),
+            "primary_recipient_group": primary,
+            "additional_recipient_groups": additional,
+            "activity_description": normalize_ws(row[10]),
+        }
+    return records
+
+
+# --- read the shared Google Form export ---------------------------------
+
+def load_form_responses(path):
+    """Return the latest Software-deliverable response per Contribution ID."""
+    if path is None:
+        return {}
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    responses = {}
+    for row in rows:
+        if row.get("Contribution deliverable type", "").strip() != "Software":
+            continue
+        cid = row.get("Contribution ID", "").strip()
+        if not cid:
+            continue
+        # Later rows (later timestamps) win if a team resubmits.
+        responses[cid] = row
+    return responses
+
+
+DATASET_FIELD_MAP = {
+    "Data Type": "data_type",
+    "Total Data Volume & Scale": "data_volume",
+    "Data Schema / Data Dictionary Link": "data_schema_link",
+    "Hosting Location": "hosting_location",
+    "Access URL or DOI": "access_url",
+    "Access Mechanisms": "access_mechanisms",
+    "Authentication & Access Restrictions": "authentication",
+    "Generation Methods": "generation_methods",
+    "Validation Status & Known Limitations": "validation_limitations",
+    "Tutorials, Examples, & Documentation": "tutorials_docs",
+    "Community Support Channel": "support_channel",
+    "Citation and Acknowledgment": "citation",
+    "Maintenance Plan & Updates": "maintenance_plan",
+    "Describe any planned updates or maintenance": "maintenance_notes",
+    "Final report": "final_report",
+}
+LIST_VALUED_DATASET_FIELDS = {"data_type", "access_mechanisms"}
+
+
+def split_list(value):
+    return [v.strip() for v in (value or "").split(",") if v.strip()]
+
+
+def build_associated_dataset(response):
+    if normalize_ws(response.get("Were any data products expected as part of this contribution?", "")) != "Yes":
+        return None
+    out = {"submitted": True}
+    # DATASET_FIELD_MAP has two Google Form columns sharing the label
+    # "Maintenance Plan & Updates" / "Describe any planned updates or
+    # maintenance" with the software section above -- DictReader only keeps
+    # the last column of a repeated header, which for this form is the
+    # dataset-section instance, so this direct lookup is correct here.
+    for form_col, out_key in DATASET_FIELD_MAP.items():
+        value = normalize_ws(response.get(form_col))
+        if out_key in LIST_VALUED_DATASET_FIELDS:
+            out[out_key] = split_list(value)
+        else:
+            out[out_key] = value
+    return out
+
+
+def merge_form_response(record, response):
+    record["submitted"] = True
+    record["email"] = normalize_ws(response.get("Email Address"))
+    record["submitter_name"] = normalize_ws(response.get("Name (first last)"))
+    record["target_audience"] = normalize_ws(response.get("Target Audience"))
+    record["software_name"] = normalize_ws(response.get("Software/Package/Dataset Name"))
+    record["version"] = normalize_ws(response.get("Version of the Software/Package/Dataset "))
+    record["software_url"] = normalize_ws(response.get("Software URL"))
+    record["documentation"] = normalize_ws(response.get("Documentation"))
+    record["verification_testing"] = normalize_ws(response.get("Verification and testing"))
+    record["sharing_of_software"] = normalize_ws(response.get("Sharing of the software"))
+    record["publications"] = normalize_ws(response.get("Publications"))
+    record["acknowledgements"] = normalize_ws(response.get("Acknowledgements text"))
+    record["support"] = normalize_ws(response.get("Support"))
+    record["maintenance_plan"] = normalize_ws(response.get("Maintenance Plan & Updates"))
+    record["maintenance_notes"] = normalize_ws(response.get("Describe any planned updates or maintenance"))
+    record["further_development"] = normalize_ws(response.get("Further development"))
+    record["other_feedback"] = normalize_ws(response.get("Any other feedback"))
+    uat_category = split_list(response.get("Unified Astronomy Thesaurus (UAT) Category"))
+    record["uat_category"] = uat_category or None
+    record["uat_concepts"] = normalize_ws(response.get("Specific UAT Concepts"))
+    record["associated_dataset"] = build_associated_dataset(response)
+
+
+# --- cross-page relation lookup -----------------------------------------
+
+def collect_existing_ids(data_dir):
+    """Map contribution_id -> title for every record already on disk under
+    a _data directory (contribution_id may be a scalar or a list, per the
+    Telescopes page's multi-facility records)."""
+    out = {}
+    if not data_dir.exists():
+        return out
+    for path in sorted(data_dir.glob("*.yaml")):
+        with path.open(encoding="utf-8") as f:
+            rec = yaml.safe_load(f) or {}
+        cid = rec.get("contribution_id")
+        cids = cid if isinstance(cid, list) else [cid]
+        for c in cids:
+            if c:
+                out[c] = rec.get("title") or rec.get("facility") or c
+    return out
+
+
+# --- YAML record assembly ------------------------------------------------
+
+def default_form_data(row):
+    return {
+        "category": row["category"],
+        "primary_recipient_group": row["primary_recipient_group"],
+        "additional_recipient_groups": row["additional_recipient_groups"],
+        "activity_description": row["activity_description"],
+        "submitted": False,
+        "email": None,
+        "submitter_name": None,
+        "target_audience": None,
+        "software_name": None,
+        "version": None,
+        "software_url": None,
+        "documentation": None,
+        "verification_testing": None,
+        "sharing_of_software": None,
+        "publications": None,
+        "acknowledgements": None,
+        "support": None,
+        "maintenance_plan": None,
+        "maintenance_notes": None,
+        "further_development": None,
+        "other_feedback": None,
+        "uat_category": None,
+        "uat_concepts": None,
+        "associated_dataset": None,
+    }
+
+
+def write_yaml(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=88)
+
+
+def sync(contributions_csv, form_responses_csv):
+    SOFTWARE_DIR.mkdir(parents=True, exist_ok=True)
+    contributions = load_contributions(contributions_csv)
+    form_responses = load_form_responses(form_responses_csv)
+
+    dataset_titles = collect_existing_ids(DATASETS_DIR)
+    telescope_titles = collect_existing_ids(TELESCOPES_DIR)
+    known_dataset_ids = set(dataset_titles)
+
+    created, updated, drafts_written = [], [], []
+
+    for cid, row in sorted(contributions.items()):
+        form_data = default_form_data(row)
+        response = form_responses.get(cid)
+        if response:
+            merge_form_response(form_data, response)
+
+        assoc = form_data.get("associated_dataset")
+        will_draft_dataset = bool(assoc) and cid not in known_dataset_ids
+        related = []
+        if cid in dataset_titles or cid in telescope_titles or will_draft_dataset:
+            related.append(cid)
+
+        out_path = SOFTWARE_DIR / f"{cid}.yaml"
+        existing = None
+        if out_path.exists():
+            with out_path.open(encoding="utf-8") as f:
+                existing = yaml.safe_load(f) or {}
+
+        record = {
+            "contribution_id": cid,
+            "title": row["title"],
+            "country": row["country"],
+            "institute": row["institute"],
+            "form_data": form_data,
+        }
+        if existing and existing.get("curated"):
+            record["curated"] = existing["curated"]
+            (updated if existing else created).append(cid)
+        else:
+            record["curated"] = {
+                "uat_keywords": guess_uat_keywords(
+                    row["title"], row["activity_description"], row["primary_recipient_group"]
+                ),
+                "summary": None,
+                "status_override": None,
+                "related_contribution_ids": related,
+            }
+            created.append(cid)
+
+        write_yaml(out_path, record)
+
+        # Auto-draft a companion Datasets record when this contribution's
+        # form response says data products are expected and no Datasets
+        # record exists for this ID yet -- flagged for coordinator review.
+        if will_draft_dataset:
+            draft_path = DATASETS_DIR / f"{cid}.yaml"
+            draft = {
+                "contribution_id": cid,
+                "title": f"{row['title']} (associated dataset)",
+                "country": row["country"],
+                "institute": row["institute"],
+                "form_data": assoc,
+                "curated": {
+                    "primary_recipient": row["primary_recipient_group"],
+                    "target_audience": form_data.get("target_audience"),
+                    "summary": None,
+                    "wavelength_regime": [],
+                    "status_override": None,
+                    "related_contribution_ids": [cid],
+                    "needs_review": True,
+                },
+            }
+            write_yaml(draft_path, draft)
+            known_dataset_ids.add(cid)
+            drafts_written.append(cid)
+
+    print(f"{len(contributions)} software records processed "
+          f"({len(created)} new/first-touch, {len(updated)} pre-existing curated preserved)")
+    if drafts_written:
+        print(f"NEEDS-REVIEW: drafted {len(drafts_written)} companion dataset "
+              f"record(s), please review before merging: {', '.join(drafts_written)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contributions", required=True, type=Path)
+    parser.add_argument("--form-responses", type=Path, default=None)
+    args = parser.parse_args()
+    sync(args.contributions, args.form_responses)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new Contributed Software page (`docs/contribution-types/contributed-software.rst`) listing software-development in-kind contributions, mirroring the Contributed Datasets page's filterable card/table layout.

- New `conf.py` Jinja loader for per-record YAML under `docs/contribution-types/_data/software/`
- Migration script (`scripts/sync_software_contributions.py`) converting the 89-row contribution spreadsheet + Google Form responses into 82 YAML records (General Pool category excluded, already covered by its own page)
- Filters: Category, UAT keyword, Primary Recipient Group, Status (Delivered/Pending)
- Cross-linking between Software and Datasets cards for shared contribution IDs (UKD-UKD-S10, SZA-SAA-S2), plus an auto-drafted, flagged-for-review Datasets record for SER-SAG-S1 (software contribution that also produced a dataset)
- Fixes a duplicate-form-column bug that had been silently swapping software/dataset Maintenance Plan answers
- Adds `ser-sag.pmf.kg.ac.rs` to `linkcheck_ignore` (expired SSL cert on an external site, unrelated to this change)