### PR TITLE
Software page: In Progress label, repo/doc links, approx start date

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -576,6 +576,43 @@ def _software_status(record):
     return "delivered" if (record.get("form_data") or {}).get("submitted") else "pending"
 
 
+_URL_RE = re.compile(r"https?://[^\s,]+")
+_FY_RE = re.compile(r"\bFY(\d{2})\b")
+
+
+def _extract_links(text):
+    """Split a free-text field like 'QhX source repository: <url>, package
+    page: <url>' into individual (label, url) pairs. Team-submission form
+    answers routinely list several URLs in one text blob rather than a
+    single clean link; this pulls each one out with whatever label text
+    preceded it so the card can render real clickable links instead of an
+    unlinked wall of text."""
+    if not text:
+        return []
+    links = []
+    for segment in text.split(","):
+        segment = segment.strip()
+        match = _URL_RE.search(segment)
+        if not match:
+            continue
+        url = match.group(0).rstrip(".,;)")
+        label = segment[: match.start()].strip(" :")
+        links.append({"label": label or url, "url": url})
+    return links
+
+
+def _approx_start_fy(timeline_text):
+    """Best-effort 'start' signal pulled from the proposal spreadsheet's
+    free-text Timeline column -- those are FTE-by-fiscal-year narratives
+    (e.g. 'FY21: ... FY22: ...'), not a clean date, so this only ever
+    surfaces the first FY mentioned as a rough indicator, never a precise
+    start date."""
+    if not timeline_text:
+        return None
+    match = _FY_RE.search(timeline_text)
+    return f"FY{match.group(1)}" if match else None
+
+
 def _resolve_related_titles(related_ids, *page_lookups):
     """page_lookups is a sequence of (page_html_filename, {contribution_id: title})
     pairs, checked in order, so the returned dicts know which page to link to."""
@@ -638,6 +675,9 @@ def _load_contributed_software():
         record["cid_slug"] = cid_slug
         record["last_updated"] = _last_updated(path)
         record["uat_keywords"] = uat_keywords
+        record["software_links"] = _extract_links(form_data.get("software_url"))
+        record["documentation_links"] = _extract_links(form_data.get("documentation"))
+        record["approx_start"] = _approx_start_fy(form_data.get("timeline"))
         record["related"] = _resolve_related_titles(
             curated.get("related_contribution_ids"),
             ("contributed-datasets.html", dataset_titles),

--- a/docs/contribution-types/_data/software/AUS-AAL-S2.yaml
+++ b/docs/contribution-types/_data/software/AUS-AAL-S2.yaml
@@ -27,6 +27,7 @@ form_data:
     in the current Low Surface Brightness Working Group Challenges, within the context of
     the Galaxies SC. Should travel become possible, travel to meet with the Rubin DM team
     will be supported.'
+  timeline: 'FY21: Software engineer, 0.25 FTEFY22: Software engineer, 0.75 FTE'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/BRA-LIN-S3.yaml
+++ b/docs/contribution-types/_data/software/BRA-LIN-S3.yaml
@@ -16,6 +16,10 @@ form_data:
     this risk, the members are engaged with the Pipeline Scientist group and interacting within
     the DESC TJP working group. If necessary LIneA also provides computing infrastructure
     that can be used to run and test the developed codes.
+  timeline: 'FY21: Dr. Felipe Andrade-Oliveira (postdoc, 0.25 FTE), Dr. Vitenti (0.25 FTE).FY22:
+    Dr. Felipe Andrade-Oliveira (postdoc, 0.25 FTE), Dr. Vitenti (0.25 FTE).FY23: Dr. Felipe
+    Andrade-Oliveira (postdoc, 0.25 FTE), Dr. Vitenti (0.25 FTE).FY24: Dr. Felipe Andrade-Oliveira
+    (postdoc, 0.25 FTE), Dr. Vitenti (0.25 FTE).'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/BRA-LIN-S4.yaml
+++ b/docs/contribution-types/_data/software/BRA-LIN-S4.yaml
@@ -58,6 +58,12 @@ form_data:
     using the computer clusters already available in LIneA''s datacenter. The remaining resources
     are dependent on the approval and subsequent implementation of the Brazilian IDAC, so
     the risk associated with this work is coupled with the IDAC project''s success.'
+  timeline: 'FY21: Design phase - total 0.95 FTEDr. Julia Gschwend (scientist, 0.25 FTE)Mr.
+    Cristiano Singulani (software developer, 0.5 FTE)Mr. Carlos Adean (system analyst, 0.2
+    FTE)FY22-FY24: Development phase - total 2.85 FTEDr. Julia Gschwend (postdoc, 0.25 FTE)Mr.
+    Cristiano Singulani (software developer, 0.5 FTE)Mr. Carlos Adean (system analyst, 0.2
+    FTE)FY25-FY34: Operation phase (until after DR10) - total 4 FTEDr. Julia Gschwend (postdoc,
+    0.2 FTE)Mr. Cristiano Singulani (software developer, 0.2 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CAN-CAN-S3.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S3.yaml
@@ -21,6 +21,15 @@ form_data:
     of the collaboration, and supporting the collaboration’s members in the use of the code.
     In addition to DESC resources, the staff will use the CLASP computing resources if needed
     to complete these tasks.
+  timeline: 'FY23-FY27: The Canadian LSST Consortium will hire postdoctoral fellows with software
+    carpentry skills (typically on 3 year contracts) to provide directable support of the
+    Dark Energy Science Collaboration. The postdoctoral fellows will be hired sequentially,
+    one from start FY23- end FY25 and one from start FY25- end FY27. This proposal has been
+    shown to DESC leadership, who have also agreed to the staggered start to the postdoctoral
+    fellows.FY23: New hire 1 (post-doc/software engineer, 0.5FTE)FY24: New hire 1 (post-doc/software
+    engineer, 0.5FTE)FY25: New hire 1 (post-doc/software engineer, 0.5FTE), New hire 2 (post-doc/software
+    engineer, 0.5FTE)FY26: New hire 2 (post-doc/software engineer, 0.5FTE)FY27: New hire 2
+    (post-doc/software engineer, 0.5FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CAN-CAN-S4.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S4.yaml
@@ -16,6 +16,9 @@ form_data:
     input from the rest of the collaboration, and supporting the collaboration’s members in
     the use of the code. The staff will use the CLASP computing resources if needed to complete
     these tasks, no additional computing support will be required from TVS resources.
+  timeline: 'FY22-FY25: The Canadian LSST Consortium will hire 2 postdoctoral fellows (typically
+    on 3 year contracts) working at 0.5 FTE/yr to provide directable support of the Transient
+    and Variable Star Science Collaboration.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CAN-CAN-S5.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S5.yaml
@@ -17,6 +17,9 @@ form_data:
     on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
     members in the use of the code. The staff will use the CLASP computing resources if needed
     to complete these tasks.
+  timeline: 'FY23-FY25: The Canadian LSST Consortium will hire a postdoctoral fellow (typically
+    on a 3 year contract) provide directable support of the LSST Galaxies Science Collaboration.
+    This brings the total to 1.5 FTE-years.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CAN-CAN-S6.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S6.yaml
@@ -32,6 +32,10 @@ form_data:
     part of the collaboration, reporting regularly on progress, taking input from the rest
     of the collaboration, and supporting the collaboration’s members in the use of the code.
     The staff will use the CLASP computing resources if needed to complete these tasks.
+  timeline: 'FY23-FY31: The Canadian LSST Consortium will hire a postdoctoral fellow (typically
+    on a 3 year contract) to provide directable support of the AGN Science Collaboration.
+    This brings the total to 1.5 FTE-years. This proposal has been endorsed by the AGN Science
+    Collaboration.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CAN-CAN-S7.yaml
+++ b/docs/contribution-types/_data/software/CAN-CAN-S7.yaml
@@ -21,6 +21,10 @@ form_data:
     taking input from the rest of the collaboration, and supporting the collaboration’s members
     in the use of the code. The staff will use the CLASP computing resources if needed to
     complete these tasks.
+  timeline: 'FY23-FY25: The Canadian LSST Consortium will hire a postdoctoral fellow (typically
+    on a 3 year contract) to provide directable support of the Solar System Science Collaboration.
+    This proposal has been endorsed by the Solar System Science Collaboration. After iteration
+    with the SSSC leadership we had left this contribution unchanged.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/CRO-RBI-S1.yaml
+++ b/docs/contribution-types/_data/software/CRO-RBI-S1.yaml
@@ -34,6 +34,9 @@ form_data:
     to define needed software development tasks, and then carry out those tasks as an integral
     part of the group, reporting regularly on progress, taking input from the rest of the
     group, and supporting the group’s members in the use of the code.'
+  timeline: 'FY21: RBI postdoc (0.125FTE)FY22: RBI postdoc (0.5 FTE)FY23: RBI postdoc (0.5
+    FTE), HO postdoc (0.5 FTE)FY24: RBI postdoc (0.5 FTE), HO postdoc (0.5 FTE)FY25: RBI postdoc
+    (0.375 FTE)Total (FY21-FY24, RBI+HO): 3.0 FTE'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ESP-BCM-S1.yaml
+++ b/docs/contribution-types/_data/software/ESP-BCM-S1.yaml
@@ -23,6 +23,7 @@ form_data:
     sufficient, as in principle most of the development and execution will be done in the
     NERSC environment. The Contribution Lead has already access and experience working with
     the DESC environment at NERSC.
+  timeline: 'FY21 through FY26: Dr. Ignacio Sevilla-Noarbe (staff, 0.25 FTE/yr).'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ESP-BCM-S3.yaml
+++ b/docs/contribution-types/_data/software/ESP-BCM-S3.yaml
@@ -22,6 +22,8 @@ form_data:
     of LSST’s Lite IDACs. The BCN-MAD team has engaged the Rubin data environment already
     through one of its team members (see Contribution 1), which would transfer the needed
     knowledge to members of this new team locally.
+  timeline: 'FY23-FY24 (est): technical postdoc hired for 0.5 FTE effort, with support from
+    staff specialists in the field.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-ARI-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-ARI-S1.yaml
@@ -22,6 +22,10 @@ form_data:
     in the Rubin tools and data products: to mitigate this, the ARI staff will engage early
     with any Rubin tutorials provided, and look to be active participants in events associated
     with the Rubin “Data Previews”, all within the context of the TVS SC.'
+  timeline: 'FY22: Dr. Yiannis Tsapras (senior postdoc, 0.5 FTE), Dr. Markus Hundertmark (senior
+    postdoc, 0.5 FTE)FY23: Dr. Yiannis Tsapras (senior postdoc, 0.5 FTE), Dr. Markus Hundertmark
+    (senior postdoc, 0.5 FTE)FY24-FY35: Dr. Yiannis Tsapras (senior postdoc, 0.2 FTE), Dr.
+    Markus Hundertmark (senior postdoc, 0.2 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-CCL-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-CCL-S1.yaml
@@ -35,6 +35,10 @@ form_data:
     In addition we have a significant number of existing experienced GCCL fellows with strong
     interests in DESC, whose efforts could be diverted to directable software development
     effort, if the task is already in line with their scientific interests.
+  timeline: 'New Hires could be either postdoctoral researchers or software engineers, depending
+    on the needs of DESC.FY22: New Hire (0.5 FTE), New Hire (0.5 FTE)FY23: New Hire (0.5 FTE),
+    New Hire (0.5 FTE)FY24: New hire (0.5 FTE), New Hire (0.5 FTE)FY25-FY35: potential continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-CCL-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-CCL-S2.yaml
@@ -29,6 +29,8 @@ form_data:
     there as well and to facilitate collaboration with other DESC researchers. Given that
     a person with very relevant expertise has already been hired, the risk associated with
     this contribution is minor.'
+  timeline: 'FY25 (or earlier): Dr. Robert Reischke (postdoc, 0.5 FTE)FY26: Dr. Robert Reischke
+    (postdoc, 0.5 FTE)FY27-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-LMU-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S1.yaml
@@ -28,6 +28,8 @@ form_data:
     them for the needs of weak lensing calibration: to mitigate this, staff will engage early
     with DESC working groups, the DESC Spokespersons and Analysis Coordinators, any tutorials
     and codes provided, and look to be active participants in the WL, PZ and BL working groups.'
+  timeline: 'FY22: Postdoc (to be hired), 0.5 FTEFY23: Postdoc (to be hired), 0.5 FTEFY22-FY35:
+    potential extended or continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-LMU-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S2.yaml
@@ -33,6 +33,9 @@ form_data:
     with the appropriate DESC working groups, analysis coordinators, and any available tutorial
     and instruction resources. We wish to be active participants in the clusters, weak lensing,
     and computing working groups and to establish fruitful scientific and technical exchange.
+  timeline: 'FY22: Postdoc #1 (to be hired), 0.5 FTE + Postdoc #2 (to be hired), 0.5 FTEFY23:
+    Postdoc #1 (continued), 0.5 FTE + Postdoc #2 (continued), 0.5 FTEFY24 onwards: potential
+    extended or continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-LMU-S3.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S3.yaml
@@ -31,6 +31,12 @@ form_data:
     is to find high level experts familiar with the complex subject. Since we have such a
     skilled person in our group now (until summer 2023) we would like to contribute our FTE
     at the earliest time possible (see below).
+  timeline: 'FY21: Dr. Tamas N. Varga (postdoc, 2/12 FTE) ! FY21=Oct 20-Sep 21FY22: Dr. Tamas
+    N. Varga (postdoc, 8/12 FTE) ! FY22=Oct 21-Sep 22FY23: Dr. Tamas N. Varga (postdoc, 2/12
+    FTE) ! FY23=Oct 22-Sep23We plan that Tamas Varga contributes 2 person months within July
+    and September 2021 (FY21) and 8 person months within October 2021 and September 2022 (FY22)
+    and 2 person months at the beginning of the FY23. Hence the effort in FY21 and FY23 will
+    also be a high level effort, but for a shorter time.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-LMU-S4.yaml
+++ b/docs/contribution-types/_data/software/GER-LMU-S4.yaml
@@ -31,6 +31,9 @@ form_data:
     catalogs to calibrate the cluster selection function. This can be mitigated with the staff
     to closely collaborate with the simulations group of LSST-DESC to ensure the useful development
     of simulations.
+  timeline: '10/21-9/23: 2 Postdocs (to be hired, 0.5 FTE per year per Postdoc), Sum: 2.0
+    FTE10/23-9/27: Postdoc (to be hired), Sum: 0.4 FTEFY27-FY35: potential extended or continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-MPE-S1.yaml
+++ b/docs/contribution-types/_data/software/GER-MPE-S1.yaml
@@ -31,6 +31,14 @@ form_data:
     and look to be active participants in events associated with the Rubin “Data Previews”,
     all within the context of the AGN SC, of which the Proposal Lead is already an active
     member.
+  timeline: 'FY22: New Hire (postdoc 0.7 FTE), s/w eng. (0.2 FTE)FY23: New Hire (postdoc 0.7
+    FTE), s/w eng. (0.2 FTE)FY24: New Hire (postdoc 0.3 FTE), s/w eng. (0.2 FTE)FY25: New
+    Hire (postdoc 0.3 FTE), s/w eng. (0.2 FTE)FY25-FY35: potential continued contribution
+    of development effort.We note that the post-doc hired will also be working on the closely
+    related GER-MPE-S1, allowing cross-benefit between the two contributions. Therefore the
+    combined effort in S1 and S2 is compliant with the handbook guidance. The software engineering
+    support will be at a constant level considering the related effort in S1 and S2 over the
+    four year period.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/GER-MPE-S2.yaml
+++ b/docs/contribution-types/_data/software/GER-MPE-S2.yaml
@@ -28,6 +28,11 @@ form_data:
     events associated with the Rubin “Data Previews”, all within the context of the AGN SC.
     The AGN SC and in particular the AGN photo-z group within the SC has endorsed this proposed
     contribution.'
+  timeline: 'FY22: New Hire (postdoc 0.1 FTE)FY23: New Hire (postdoc 0.1 FTE)FY24: New Hire
+    (postdoc 0.3 FTE)FY25: New Hire (postdoc 0.4 FTE)FY25-FY35: potential continued contribution
+    of development effort.We note that the post-doc hired will also be working on the closely
+    related GER-MPE-S1, allowing cross-benefit between the two contributions. Therefore the
+    combined effort in S1 and S2 is compliant with the handbook guidance.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/HUN-KON-S2.yaml
+++ b/docs/contribution-types/_data/software/HUN-KON-S2.yaml
@@ -38,6 +38,9 @@ form_data:
     the TVS Science Collaboration. This idea is supported by Croatian, Hungarian, Serbian
     and Slovenian institutions sharing similar interests and expertise in time-domain astronomy
     and astrophysics and willing to commit resources towards its development.'
+  timeline: 'FY21-FY22: Attila Bódi (Konkoly) 0.5 FTE/yr postdoc, astronomer FY21-FY22: Tamás
+    Szklenár (Konkoly) 0.5 FTE/yr programmerFY23-FY35: potential new hire (0.2 FTE/yr) continued
+    contribution to the development and maintenance effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-ISR-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-ISR-S1.yaml
@@ -21,6 +21,8 @@ form_data:
     any Rubin tutorials provided to gain expertise in handling Rubin specific challenges ,
     and look to be active participants in events associated with the Rubin “Data Previews”,
     all within the context of the TVS SC. S1.
+  timeline: 'FY24-25: New hire (postdoc, 0.5 FTE)FY26-FY35: potential continued contribution
+    of development effort.S1.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-ITI-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-ITI-S1.yaml
@@ -21,6 +21,8 @@ form_data:
     IIT staff will engage early with any Rubin tutorials provided, and look to be active participants
     in events associated with the Rubin “Data Previews”, all within the context of the AGN
     SC.'
+  timeline: 'FY23-24 (flexible): New hire (postdoc, 0.5 FTE)FY25-26 (flexible): New hire (postdoc,
+    0.5 FTE)FY27-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-ITI-S2.yaml
+++ b/docs/contribution-types/_data/software/IND-ITI-S2.yaml
@@ -23,6 +23,8 @@ form_data:
     products: to mitigate this, the IIT Indore staff will engage early with any Rubin tutorials
     provided, and look to be active participants in events associated with the Rubin “Data
     Previews”, all within the context of the Galaxies SC.'
+  timeline: 'FY23-25 (flexible): New hire (postdoc, 0.5 FTE)FY26-28 (flexible): New hire (postdoc,
+    0.5 FTE)FY29-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-IUC-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S1.yaml
@@ -23,6 +23,8 @@ form_data:
     engage early with any Rubin tutorials provided, and look to be active participants in
     events associated with the Rubin “Data Previews”, as well as the Dark Energy SC “Data
     Challenges”.'
+  timeline: 'FY23-25 (flexible): New hire (postdoc, 0.5 FTE)FY26-28 (flexible): New hire (postdoc,
+    0.5 FTE)FY29-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-IUC-S2.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S2.yaml
@@ -20,6 +20,8 @@ form_data:
     in the Rubin tools and data products: to mitigate this, the IUCAA staff will engage early
     with any Rubin tutorials provided, and look to be active participants in events associated
     with the Rubin “Data Previews”, all within the context of the Galaxies SC.'
+  timeline: 'FY23-24: New hire (postdoc, 0.5 FTE)FY25-FY35: potential continued contribution
+    of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-IUC-S3.yaml
+++ b/docs/contribution-types/_data/software/IND-IUC-S3.yaml
@@ -21,6 +21,8 @@ form_data:
     this, the IUCAA staff will engage early with any Rubin tutorials provided, and look to
     be active participants in events associated with the Rubin “Data Previews”, all within
     the context of the Galaxies SC.'
+  timeline: 'FY23-24: New hire (postdoc, 0.5 FTE)FY25-FY35: potential continued contribution
+    of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-NCR-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-NCR-S1.yaml
@@ -23,6 +23,8 @@ form_data:
     will engage early with any Rubin tutorials provided, and look to be active participants
     in events associated with the Rubin “Data Previews”, all within the context of the Galaxies
     SC.'
+  timeline: 'FY23-27 (flexible): New hire (postdoc, 0.5 FTE)FY28-FY35: potential continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/IND-TIF-S1.yaml
+++ b/docs/contribution-types/_data/software/IND-TIF-S1.yaml
@@ -21,6 +21,9 @@ form_data:
     tutorials provided, and look to be active participants in events associated with the Rubin
     “Data Previews” and the Dark Energy SC “Data Challenges”. Some of these contributions
     could also have relevance and synergy with the AGN SC and the Galaxies SC.'
+  timeline: 'FY23-25 (flexible): New hire (postdoc, 0.5 FTE per year)FY26-28 (flexible): New
+    hire (postdoc, 0.5 FTE per year)FY29-30 (flexible): New hire (postdoc, 0.5 FTE per year)FY
+    30-33: Potential continued contribution to the development effort'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ISR-UST-S1.yaml
+++ b/docs/contribution-types/_data/software/ISR-UST-S1.yaml
@@ -20,6 +20,12 @@ form_data:
     UV light curves will be connected with LSST events (either transients or static sources
     - e.g., for stellar flares). This will allow curators of LSST data to add the public ULTRASAT
     light curves to the aggregated information about these LSST sources.
+  timeline: 'Proposed timeline is appended below: December 2025 - begin technical discussions
+    between ULTRASAT and LSST alert teams June 2026 - finalize discussions and produce a document
+    with agreed protocols June 2026 - set a test machine at Weizmann (ULTRASAT Data center)
+    to undertake communication tests During 2027 - conduct tests using incoming LSST test
+    alert stream; develop algorithm and routines to associate ULTRASAT UV light curves with
+    LSST sources prior to release.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S10.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S10.yaml
@@ -32,6 +32,17 @@ form_data:
     the INAF team will engage early with any Rubin tutorials provided, and look to be active
     participants in events associated with the Rubin “Data Previews”, all within the context
     of the TVS and SMWLV SCs.'
+  timeline: 'FY23: New hire (postdoc, 0.8 FTE), Massimo Dall’Ora (staff scientist, 0.3 FTE),
+    G. Bono (staff scientist, 0.1 FTE, M. Di Criscienzo (staff scientist, 0.1 FTE), G. Fiorentino
+    (staff scientist, 0.1FTE), I. Musella (staff scientist, 0.1FTE)FY24: New hire (postdoc,
+    0.8 FTE), Massimo Dall’Ora (staff scientist, 0.3 FTE), G. Bono (staff scientist, 0.1 FTE,
+    M. Di Criscienzo (staff scientist, 0.1 FTE), G. Fiorentino (staff scientist, 0.1FTE),
+    I. Musella (staff scientist, 0.1FTE)FY25: New hire (postdoc, 0.8 FTE), Massimo Dall’Ora
+    (staff scientist, 0.3 FTE), G. Bono (staff scientist, 0.1 FTE, M. Di Criscienzo (staff
+    scientist, 0.1 FTE), G. Fiorentino (staff scientist, 0.1FTE), I. Musella (staff scientist,
+    0.1FTE).FY26: New hire (postdoc, 0.8 FTE), Massimo Dall’Ora (staff scientist, 0.3 FTE),
+    G. Bono (staff scientist, 0.1 FTE, M. Di Criscienzo (staff scientist, 0.1 FTE), G. Fiorentino
+    (staff scientist, 0.1FTE), I. Musella (staff scientist, 0.1FTE).'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S11.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S11.yaml
@@ -27,6 +27,8 @@ form_data:
     and build-in pipelines. In order to mitigate this problem, we plan to engage early with
     Rubin SW developers and look to be active participants in forthcoming Rubin “Data Previews”
     within the context of the SSSC.
+  timeline: 'FY23: New hire (postdoc, 1.0 FTE), + Staff scientists, 0.3 FTEFY24: New hire
+    (postdoc, 1.0 FTE), + Staff scientists, 0.3 FTE'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S12.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S12.yaml
@@ -32,6 +32,16 @@ form_data:
     to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
     look to be active participants in events associated with the Rubin “Data Previews”, all
     within the context of the SMWLV and TSV Science Collaboration.'
+  timeline: 'FY25: New hire (postdoc, 0.8 FTE), + Sara Lucatello 0.1 FTE (software design
+    and validation), Antonella Vallenari 0.1 FTE (management of spectroscopic data and validation),FY26:
+    New hire (postdoc, 0.8 FTE), + Sara Lucatello 0.1 FTE (software design and validation),
+    Antonella Vallenari 0.1 FTE (management of spectroscopic data and validation)Postdocs
+    will be hired full time, but dedicate 0.8FTE/yr to the contribution to Rubin, maintaining
+    0.2FTE/yr for scientific research. Whether this will be a single postdoc contributing
+    with 0.8FTE in TVS the first year and 0.8FTE to SMWLV in the second year (or vice versa),
+    or two different postdocs working each at 0.8FTE for one year with one of the collaborations,
+    or the full FTEs will be contributed to a single collaboration will be determined in due
+    course, taking into account Rubin’s needs.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S13.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S13.yaml
@@ -26,6 +26,10 @@ form_data:
     to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
     look to be active participants in events associated with the Rubin “Data Previews”, all
     within the context of the I&S SC.'
+  timeline: 'FY26: New hire (postdoc for software development/engineering, 1.0 FTE), + E.
+    Merlin (Staff scientist, 0.2 FTE)FY27: New hire (postdoc for software development/engineering,
+    1.0 FTE), + E. Merlin (Staff scientist, 0.2 FTE)FY28: New hire (postdoc for software development/engineering,
+    1.0 FTE), + E. Merlin (Staff scientist, 0.2 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S14.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S14.yaml
@@ -29,6 +29,12 @@ form_data:
     the INAF team will engage early with any DESC tutorials provided, and look to be active
     participants in events associated with the Rubin “Data Previews”, all within the context
     of the DESC.'
+  timeline: 'FY25: New hire (postdoc, 0.7 FTE), Dr Marco Baldi (Staff Scientist, 0.1FTE),
+    Dr Mauro Sereno (Staff Scientist, 0.1FTE), Dr Alex Saro(Staff scientist, 0.1FTE)FY26:
+    New hire (postdoc, 0.7 FTE), Dr Marco Baldi (Staff Scientist, 0.1FTE), Dr Mauro Sereno
+    (Staff Scientist, 0.1FTE), Dr Alex Saro(Staff scientist, 0.1FTE)FY27: New hire (postdoc,
+    0.7 FTE), Dr Marco Baldi (Staff Scientist, 0.1FTE), Dr Mauro Sereno (Staff Scientist,
+    0.1FTE), Dr Alex Saro(Staff scientist, 0.1FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S15.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S15.yaml
@@ -32,6 +32,9 @@ form_data:
     will need to quickly become familiar with the Rubin tools and data products. To this end
     the INAF team will engage early with any tutorials provided by RO, and will actively participate
     in events of the TVS SC associated with the Rubin “Data Previews”.
+  timeline: 'FY25: New hire (postdoc, 0.8 FTE), Gisella Clementini (Staff scientist, 0.1 FTE),
+    Vincenzo Ripepi (Staff scientist, 0.1 FTE)FY26: New hire (postdoc, 0.8 FTE), Gisella Clementini
+    (Staff scientist, 0.1 FTE), Vincenzo Ripepi (Staff scientist, 0.1 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S2.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S2.yaml
@@ -35,6 +35,9 @@ form_data:
     personnel: to mitigate this, the INAF team will engage early with any Rubin tutorials
     provided, and look to be active participants in events associated with the Rubin “Data
     Previews” within the context of the AGN SC.'
+  timeline: 'FY23: New hire (postdoc, 0.8 FTE), A. Bongiorno (Staff scientist, 0.1 FTE) and
+    M. Mignoli (Staff scientist, 0.1 FTE)FY24: New hire (postdoc, 0.8 FTE), A. Bongiorno (Staff
+    scientist, 0.1 FTE) and M. Mignoli (Staff scientist, 0.1 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S23.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S23.yaml
@@ -31,6 +31,16 @@ form_data:
     in events associated with the Rubin “Data Previews”, all within the context of the I&S
     SC.More technical and functional information on the prototype system offered is available
     here: https://drive.google.com/drive/folders/1iXAoA8OS9G1Srl7erVu9zQ-EdWVm5Rkj?usp=sharing'
+  timeline: 'FY22: New hire (postdoc, 0.9 FTE), Stefano Cavuoti (Staff scientist , 0.1 FTE),
+    Massimo Brescia (Staff scientist, 0.1 FTE)FY23: New hire (postdoc, 0.9 FTE), Stefano Cavuoti
+    (Staff scientist , 0.1 FTE), Massimo Brescia (Staff scientist, 0.1 FTE)FY24: New hire
+    (postdoc, 0.9 FTE), Stefano Cavuoti (Staff scientist , 0.1 FTE), Massimo Brescia (Staff
+    scientist, 0.1 FTE)FY25-FY35: potential continued contribution of development effort.We
+    specify that Staff proposers, Stefano Cavuoti and Massimo Brescia will be the assignees
+    of the staff contribution, quantified in 0.2 FTE/y. Their contribution will be technical
+    and data analysis design and development effort to support the SW engineering tasks provided
+    by the hired personnel. In particular, Stefano Cavuoti is the contact point for the SitCom
+    team.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S25.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S25.yaml
@@ -36,6 +36,44 @@ form_data:
     Brazilian team at Linea, who is submitting a separated in-kind request), the space-resolved
     star-formation history of nearby galaxies, etc. This is a non-directable in-kind contribution
     endorsed by the SMWLV Collaboration. S25'
+  timeline: 'FY18: Dr. Léo Girardi (staff, 0.1 FTE), Dr. Giada Pastorelli (graduate student,
+    0.2 FTE), Dr. Piero Dal Tio (graduate student, 0.2 FTE), Dr. Michele Trabucchi (postdoc,
+    0.2 FTE), Dr. Yang Chen (postdoc, 0.1 FTE), Dr. Simone Zaggia (staff, 0.05 FTE), Dr. Yazan
+    Momany (staff, 0.05 FTE)FY19: Dr. Léo Girardi (staff, 0.2 FTE), Dr. Giada Pastorelli (postdoc,
+    0.2 FTE), Dr. Piero Dal Tio (graduate student, 0.3 FTE), Dr. Michele Trabucchi (postdoc,
+    0.2 FTE) Dr. Yang Chen (postdoc, 0.1 FTE), Dr. Simone Zaggia (staff, 0.05 FTE), Dr. Yazan
+    Momany (staff, 0.05 FTE)FY20: Dr. Léo Girardi (staff, 0.2 FTE), Dr. Giada Pastorelli (postdoc,
+    0.1 FTE), Dr. Piero Dal Tio (graduate student, 0.3 FTE), Dr. Michele Trabucchi (postdoc,
+    0.2 FTE), Dr. Simone Zaggia (staff, 0.05 FTE), Dr. Yazan Momany (staff, 0.05 FTE), Dr.
+    Alessandro Mazzi (graduate student, 0.1 FTE)FY21: Dr. Léo Girardi (staff, 0.2 FTE), Dr.
+    Simone Zaggia (staff, 0.2 FTE), Yazan Momany (staff, 0.2 FTE), Dr. Alessandro Mazzi (graduate
+    student, 0.1 FTE)Milestone 1 (early-2021): ensuring the best usage of present simulations
+    on MAF. This is ongoing work, in the context of the Cadence Notes from the SMWLV Science
+    Collaboration.Milestone 2 (mid-2021): To complete the installation of the 1st complete
+    simulation in NOIR Data Lab together with a minimal set of jupyter notebooks (e.g. star
+    counts and distributions of intrinsic stellar parameters for different color-magnitude
+    cuts). The exact data of release depends on the interaction with NOIR Data Lab staff.FY22:
+    New hire (postdoc, 0.75 FTE), Dr. Léo Girardi (staff, 0.2 FTE), Dr. Simone Zaggia (staff,
+    0.2 FTE), Yazan Momany (staff, 0.2 FTE)FY23: New hire (postdoc, 0.75 FTE), Dr. Léo Girardi
+    (staff, 0.2 FTE), Dr. Simone Zaggia (staff, 0.2 FTE), Yazan Momany (staff, 0.2 FTE)Milestone
+    3 (early-2023): Release of the second simulation, now with detailed binary parameters
+    (including eclipses), basic variability parameters (dominant modes, periods), and an extended
+    set of jupyter notebooks.FY24: Dr. Léo Girardi (staff, 0.2 FTE), Dr. Simone Zaggia (staff,
+    0.2 FTE), Yazan Momany (staff, 0.2 FTE)Milestone 4 (mid-2024): Release of the third simulation,
+    ensuring a better match to star counts from Gaia latest (or last) data release.FY25: Dr.
+    Léo Girardi (staff, 0.2 FTE), Dr. Simone Zaggia (staff, 0.2 FTE), Yazan Momany (staff,
+    0.2 FTE)Milestone 5 (late-2025): Release of the fourth simulation, with added light curves
+    and a careful check of basic predictions with first LSST data, plus jupyter notebooks
+    to facilitate LSST data-model comparisons.FY26-FY35: potential continued contribution
+    of development effort.We recall that each one of these milestones will involve a number
+    of small simulations being done in our computers in Padova, and checked against basic
+    data from Gaia and a variety of other public surveys. While Leo Girardi, Alessandro Mazzi
+    and the new postdoc will concentrate on developing and scaling up the software, Simone
+    Zaggia and Yazan Momany, with their decennial experience in wide-area and multi-epoch
+    photometric surveys of the Local Group, will be checking the results of these small-scale
+    simulations (and contributing to the library of jupyter notebooks), especially in the
+    periods immediately before their release.The contribution lead, Leo Girardi, will act
+    as the main point of contact to the recipient group throughout the course of the contribution,'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S26.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S26.yaml
@@ -29,6 +29,10 @@ form_data:
     and we will work to secure additional local resources if needed. INAF will also provide
     a dedicated postdoc grant to the project.The TVS SC and SWMLV SC have endorsed this proposed
     contribution.'
+  timeline: 'FY26: New hire (postdoc), 1.0 FTE + Dr. Lucio A. Antonelli (staff, 0.1 FTE),
+    Dr. Giuseppe Altavilla (staff, 0.1 FTE) FY27: New hire (postdoc), 1.0 FTE + Dr. Lucio
+    A. Antonelli (staff, 0.1 FTE), Dr. Giuseppe Altavilla (staff, 0.1 FTE) FY28-34: Staff
+    Scientists 0.2 FTE'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S3.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S3.yaml
@@ -36,6 +36,12 @@ form_data:
     participants in events associated with the Rubin “Data Previews”.Both proposers are members
     of the Stack Club, (Bonito is the Chair of the TVS Task Force on the Rubin Science Platform
     Evaluation).'
+  timeline: 'FY25: New hire (postdoc, 0.7 FTE), Rosaria Bonito (staff scientist 0.1 FTE),
+    Teresa Giannini (staff scientist 0.1 FTE), Loredana Prisinzano (staff scientist 0.1 FTE)
+    FY26: New hire (postdoc, 0.7 FTE), Rosaria Bonito (staff scientist 0.1 FTE), Teresa Giannini
+    (staff scientist 0.1 FTE), Alessio Caratti o Garatti (staff scientist 0.1 FTE)FY27: New
+    hire (postdoc, 0.7 FTE), Rosaria Bonito (staff scientist 0.1 FTE), Teresa Giannini (staff
+    scientist 0.1 FTE), Mario Guarcello (staff scientist 0.1 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S5.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S5.yaml
@@ -26,6 +26,10 @@ form_data:
     to mitigate this, the INAF team will engage early with any Rubin tutorials provided, and
     look to be active participants in events associated with the Rubin “Data Previews”, all
     within the context of the SMWLV SC.'
+  timeline: 'FY26: New hire (postdoc, 0.7 FTE), Innocenza Busà (staff scientist 0.1 FTE),
+    Francesco Leone (staff scientist 0.1 FTE) and Corrado Trigilio (staff scientist 0.1 FTE)FY27:
+    New hire (postdoc, 0.7 FTE), Innocenza Busà (staff scientist 0.1 FTE), Francesco Leone
+    (staff scientist 0.1 FTE) and Corrado Trigilio (staff scientist 0.1 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S6.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S6.yaml
@@ -36,6 +36,9 @@ form_data:
     pipeline (assuming it is fast enough).We anticipate needing modest amounts of local computing
     to support this work, during the first stages of the project, in part already available.
     Other resources will be acquired via national or local funding.'
+  timeline: FY25:New hire (postdoc, 1.0 FTE) + staff researcher (0.2 FTE) FY26:New hire (postdoc,
+    1.0 FTE) + staff researcher (0.2 FTE) FY27:New hire (postdoc, 1.0 FTE) + staff researcher
+    (0.2 FTE)
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S8.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S8.yaml
@@ -27,6 +27,8 @@ form_data:
     types of models and software tools for the future analysis of the LSST data for pulsating
     stars in different Galactic and extragalactic environments are also described in the TVS
     Roadmap in the Section 'Transients and variables of the Galactic and Local Intrinsic Universe'.
+  timeline: 'FY23: New hire (postdoc, 1.0 FTE) + Marconi+Musella (staff researcher, 0.2 FTE)
+    FY24: New hire (postdoc, 1.0 FTE) + Marconi+Musella (staff researcher, 0.2 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/ITA-INA-S9.yaml
+++ b/docs/contribution-types/_data/software/ITA-INA-S9.yaml
@@ -30,6 +30,8 @@ form_data:
     the INAF team will engage early with any Rubin tutorials provided, and look to be active
     participants in events associated with the Rubin “Data Previews”, all within the context
     of the Galaxy and Strong Lensing Science Collaboration (GSC an SLSC) and DM.'
+  timeline: 'FY23: New hire (postdoc, 0.8 FTE) + C. Tortora (staff researcher, 0.2 FTE) FY24:
+    New hire (postdoc, 0.8 FTE) + C. Tortora (staff researcher, 0.2 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/JAP-JPG-S3.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S3.yaml
@@ -32,6 +32,11 @@ form_data:
     data products from HSC-SSP and the upcoming PFS survey in neighboring systems in NAOJ,
     we would discuss an efficient way to provide access to those products for synergistic
     work combining those data sets with LSST data.
+  timeline: 'If selected, the timeline of resource assignment is as follows: FY22-25: a 0.5
+    FTE of software professional, responsible for operation and development of RSP in coordination
+    with Rubin Community Engagement team and other related personnel. FY23-35: a 0.5 FTE of
+    instrument scientist for user support and software deployment of RSP in coordination with
+    Rubin Community Engagement team and other related personnel.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/JAP-JPG-S7.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S7.yaml
@@ -30,6 +30,10 @@ form_data:
     of the proposed contributions so that the contribution is smoothly integrated with the
     existing efforts and software. DESC endorses this contribution, 'Software for calibrating
     the covariance matrix for large-scale structure probes'.
+  timeline: '3-4Q of FY21: postdoc (0.25 FTE), Dr. Masahiro Takada FY22: postdoc (0.5 FTE),
+    Dr. Masahiro Takada FY23: postdoc (0.5 FTE), Dr. Masahiro TakadaComputing resources: 15M
+    CPU hours during FY21-23 (equivalent to 0.5 FTE)FY24-FY35: potential continued contribution
+    of development/maintenance effort (envisioned as 0.25 FTE in total)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/JAP-JPG-S8.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S8.yaml
@@ -36,6 +36,12 @@ form_data:
     with ML experts within DESC and the Informatics and Statistics Science Collaboration (ISSC),
     which ensures this work is well-embedded within DESC and Rubin Observatory.DESC endorses
     this contribution, with LOI code JAP-JAP-4.
+  timeline: 'FY21: Dr. Maxime Paillassa (postdoc, 0.5 FTE), Dr. Hironao Miyatake (Assistant
+    Professor, 0.1 FTE)FY22: Dr. Maxime Paillassa (postdoc, 0.5 FTE), Dr. Hironao Miyatake
+    (Assistant Professor, 0.1 FTE)FY23: Dr. Maxime Paillassa (postdoc, 0.5 FTE), Dr. Hironao
+    Miyatake (Assistant Professor, 0.1 FTE)FY24: Dr. Hironao Miyatake (Assistant Professor,
+    0.1 FTE)FY25: Dr. Hironao Miyatake (Assistant Professor, 0.1 FTE)FY24-FY27: potential
+    hire of a postdoc for continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/JAP-JPG-S9.yaml
+++ b/docs/contribution-types/_data/software/JAP-JPG-S9.yaml
@@ -22,6 +22,11 @@ form_data:
     are already available at University of Tokyo and NAOJ, although the team will also use
     NERSC to ensure broader collaboration engagement. This proposed contribution was developed
     in consultation with DESC.
+  timeline: 'FY22: Dr. Masamune Oguri (faculty, 0.2 FTE)FY23: New hire (postdoc, 0.5 FTE)
+    or Dr. Masamune Oguri (faculty, 0.2 FTE)FY24: New hire (postdoc, 0.5 FTE) or Dr. Masamune
+    Oguri (faculty, 0.2 FTE)FY25: New hire (postdoc, 0.5 FTE) or Dr. Masamune Oguri (faculty,
+    0.2 FTE)FY26: New hire (postdoc, 0.5 FTE) or Dr. Masamune Oguri (faculty, 0.2 FTE)FY27-FY35:
+    potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/MEX-UNA-S1.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S1.yaml
@@ -32,6 +32,14 @@ form_data:
     envisioned for later stages. Finally to engage within DESC and SLSC the team will join
     the regular telecoms and activities of the SCs as well as to participate actively in all
     their activities, and make use of their communication tools as well.
+  timeline: 'FY22: Dr. Alma Gonzalez (CONACYT Fellow, 0.5 FTE), Dr. Jorge Mastache (CONACYT
+    Fellow, 0.5 FTE), Mr. Julio Clemente (software engineer, 0.2 FTE), New hire (software
+    engineer, 0.2 FTE). FY23: New hire (Postdoc, 0.6 FTE), Dr. Alma Gonzalez (CONACYT Fellow,
+    0.5 FTE), Dr. Jorge Mastache (CONACYT Fellow, 0.5 FTE), New hire (software engineer, 0.2
+    FTE). FY24: New hire (postdoc, 0.6 FTE), New hire (software engineer, 0.2 FTE).FY25-35:
+    Potential continued contribution of development effort.Dr. Alma Gonzalez will act as the
+    primary contact between the team and the recipients and plans to continue to contribute
+    to the effort in FY24 funding permitting (TBD, see S1.4.1).'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/MEX-UNA-S2.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S2.yaml
@@ -26,6 +26,15 @@ form_data:
     to be active participants in all the events, and will take advantage of DESC and SCSL
     existing documentation, tools and tutorials, as well as to join the regular telecoms and
     make use of their communication tools.
+  timeline: 'FY22: Dr. Josue De-Santiago (CONACYT Fellow, 0.5 FTE), Dr. Sebastien Fromenteau
+    (Associate Professor, 0.5 FTE), Dr. J. Alberto Vazquez (Associate Professor, 0.5 FTE)
+    FY23: Dr. Josue De-Santiago (CONACYT Fellow, 0.5 FTE), Dr. Sebastien Fromenteau (Associate
+    Professor, 0.5 FTE), Dr. J. Alberto Vazquez (Associate Professor, 0.4 FTE) FY24: New hire
+    (Postdoc, 0.5 FTE), Dr. Sebastien Fromenteau (Associate Professor, 0.5 FTE), J. Héctor
+    Velázquez (Full Professor, 0.5 FTE)FY25: Dr. Sebastien Fromenteau (Associate Professor,
+    0.5 FTE), Héctor Velázquez (Senior, 0.5 FTE)FY26-FY35: Potential continued contribution
+    of development effort.Sebastian Fromenteau will act as the main liaison for the duration
+    of the contribution.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/MEX-UNA-S3.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S3.yaml
@@ -31,6 +31,16 @@ form_data:
     maintenance will be provided by the contributors of this proposal and according to the
     requirements of the recipient working groups.DESC endorses this proposed contribution,
     MEX-UNA-S3.'
+  timeline: 'FY22: Dr. Alejandro Aviles (CONACYT Fellow, 0.5 FTE), Dr. Gustavo Niz (Full Professor,
+    0.2 FTE), Dr. Juan Carlos Hidalgo (Full Professor, 0.2 FTE), Dr. Mario A. Rodriguez-Meza
+    (Full Professor, 0.2 FTE)FY23: Dr. Alejandro Aviles (CONACYT Fellow, 0.2 FTE), Gustavo
+    Niz (Full Professor, 0.5 FTE), Dr. Juan Carlos Hidalgo (Full Professor, 0.2 FTE), Dr.
+    J. Alberto Vazquez (Full Professor, 0.1 FTE), Dr. Mario A. Rodriguez-Meza (Full Professor,
+    0.2 FTE)FY24: Dr. Alejandro Aviles (CONACYT Fellow, 0.5 FTE), Gustavo Niz (Full Professor,
+    0.2 FTE), Dr. Juan Carlos Hidalgo (Full Professor, 0.2 FTE), Dr. J. Alberto Vazquez (Full
+    Professor, 0.2 FTE), Dr. Mario A. Rodriguez-Meza (Full Professor, 0.2 FTE)FY24-FY35: Continued
+    contribution and maintenance of the 3pts pipeline effort.GN and AA will co-lead the work
+    with AA acting as the single point of contact for the duration of the project.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/MEX-UNA-S4.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S4.yaml
@@ -21,6 +21,14 @@ form_data:
     products: to mitigate this, UNAM staff will engage early with any Rubin tutorials provided,
     and look to be active participants in events associated with the Rubin “Data Previews”,
     all within the context of the SMWLV SC.'
+  timeline: 'FY22: Dr. Héctor Velázquez (Full Professor, 0.5 FTE), Dr. Maria de los Ángeles
+    Pérez Villegas (Associate Professor, software engineer, 0.1 FTE)FY23: Dr. Héctor Velázquez
+    (Full Professor, 0.5 FTE), Dr. Maria de los Ángeles Pérez Villegas (Associate Professor
+    software engineer, 0.15 FTE), Dr. Luis Alberto Martínez Medina (Associate Professor, 0.15)FY24:
+    Dr. Maria de los Ángeles Pérez Villegas (Associate Professor, 0.5 FTE), Dr. Luis Alberto
+    Martínez Medina (Associate Professor, 0.15 FTE)FY25: Dr. Luis Alberto Martínez Medina
+    (Associate Professor, 0.5 FTE), Dr. Maria de los Ángeles Pérez Villegas (Associate Professor,
+    0.15 FTE)FY26-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/MEX-UNA-S5.yaml
+++ b/docs/contribution-types/_data/software/MEX-UNA-S5.yaml
@@ -30,6 +30,10 @@ form_data:
     applying the described techniques towards synergetic efforts with other SCs, like SLSC.We
     will be happy to extend our collaboration to other projects and share our experience if
     that is of benefit to the Galaxies SC. The Galaxies SC have endorsed this proposed contribution.
+  timeline: 'FY22: Dr. Jose Antonio Vázquez-Mata (postdoc, 0.6 FTE), Dr. G Fuentes-Pineda
+    (Full Professor, 0.2 FTE)FY23: Dr. Jose Antonio Vázquez-Mata (postdoc, 0.6 FTE), Dr. H
+    Hernández-Toledo (Full Professor, 0.3 FTE)FY24: New hire (postdoc, 0.6 FTE), Dr. H Hernández-Toledo
+    (Full Professor, 0.3 FTE)FY25-FY32: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/NED-UTR-S2.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S2.yaml
@@ -41,6 +41,7 @@ form_data:
     is timely and meaningful. Other areas where we can contribute and which have been discussed
     with LSST DESC leads are: the modelling of baryonic physics and general maintenance of
     TJP pipelines.The LSST DESC has endorsed this contribution.'
+  timeline: 'FY22: New hire (postdoc, 0.5 FTE)FY23: New hire (postdoc, 0.5 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/NED-UTR-S3.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S3.yaml
@@ -15,6 +15,10 @@ form_data:
     and supporting the coordination of group members where we can. We will coordinate with
     the Rubin Algorithms & Pipelines Team to make sure that the proposed algorithms meet their
     speed and robustness requirements.
+  timeline: 'FY22: Dr. Zuzanna Kostrzewa-Rutkowska (postdoc, 0.5 FTE)FY23: Dr. Zuzanna Kostrzewa-Rutkowska
+    (postdoc, 0.5 FTE)FY24: Dr. Zuzanna Kostrzewa-Rutkowska (postdoc, 1 FTE)This timeline
+    reflects that we anticipate the agreement on the statement of work will take some time
+    to complete as well as the ongoing obligations of Kostrzewa-Rutkowska to the Gaia DPAC.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/NED-UTR-S5.yaml
+++ b/docs/contribution-types/_data/software/NED-UTR-S5.yaml
@@ -55,6 +55,10 @@ form_data:
     a larger fraction of the galaxy. By building the best-possible AGN catalog and making
     this available before the alert stream gets up to full speed, we will avoid a scramble
     of duplicate efforts from TVS members. The TVS has endorsed this contribution.
+  timeline: 'FY22: postdoc 0.3 FTE: build catalog from non-Rubin data.FY22: van Velzen 0.1
+    FTE: quality control and delivery to NOIRLab and Brokers.FY23: postdoc, 0.4 FTE: AGN variability
+    section software and catalog production. F24+: van Velzen, 0.2 FT: continued yearly updates
+    of the variability catalog and user support.[h][i][j][k][l][m]'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/POL-NCB-S2.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S2.yaml
@@ -35,6 +35,13 @@ form_data:
     staff will be to serve DESC infrastructure. This includes installation and maintenance
     of the software and continuous monitoring of the processes, as well as participation in
     development of necessary pipelines.'
+  timeline: 'FY21: Dr. Adam Zadrożny (faculty, 0.1 FTE)FY22-F24: Dr. Adam Zadrożny (faculty,
+    0.1 FTE), new hire (IT professional or postdoc, 0.75 FTE), new hire (IT professional or
+    postdoc, 0.75 FTE)FY25-FY35: potential continued contribution of development effort.If
+    selected, the timeline of works is as follows:FY21: setting up software for DESC group
+    computing infrastructure and providing support DESC group activitiesFY22-FY24: providing
+    support DESC group activities (direct effort) and maintenance for DESC computing infrastructureFY25-FY35:
+    potential continued contribution of development effort, depending on future secured funding'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/POL-NCB-S3.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S3.yaml
@@ -28,6 +28,10 @@ form_data:
     the NCBJ staff will engage early with any Rubin tutorials provided, and look to be active
     participants in events associated with the Rubin “Data Previews”, all within the context
     of the Galaxies SC.'
+  timeline: 'FY22: Dr. Katarzyna Małek (associate professor, 0.2 FTE), new hire (post-doc,
+    0.5 FTE)FY23: Dr. Katarzyna Małek (associate professor, 0.2 FTE), new hire (post-doc,
+    0.5 FTE)FY24: Dr. Katarzyna Małek (associate professor, 0.2 FTE), new hire (post-doc,
+    0.5 FTE)FY25-FY35: potential continued contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/POL-NCB-S4.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S4.yaml
@@ -31,6 +31,11 @@ form_data:
     invest into local GPU workstations for the proposed deep-learning developments. In the
     future, this type of new equipment is aimed to be integrated with the emerging national
     node for Independent Data Access Center (IDAC).
+  timeline: 'FY22: new hire (post-doc, 0.5 FTE), supervised by Dr. Maciej BilickiFY23: new
+    hire (post-doc, 0.5 FTE), new hire (post-doc, 0.5 FTE), supervised by Dr. Maciej BilickiFY24:
+    new hire (post-doc, 0.5 FTE), new hire (post-doc, 0.5 FTE), supervised by Dr. Maciej BilickiFY25:
+    new hire (post-doc, 0.5 FTE), supervised by Dr. Maciej BilickiFY26-FY35: potential continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/POL-NCB-S6.yaml
+++ b/docs/contribution-types/_data/software/POL-NCB-S6.yaml
@@ -24,6 +24,10 @@ form_data:
     Club program, and he conveyed the acquired knowledge to the rest of the group. NCBJ will
     actively participate in forthcoming events associated with the Rubin 'Data Previews',
     all within the context of AGN SC. This plan has been consulted with AGN Science Collaboration.
+  timeline: '“Past software development effort” section of the Handbook for more detail.FY21:
+    Dr. Michal Zajacek (post-doc, 0.5 FTE), supervised by Prof. Bożena CzernyFY22: Dr. Michal
+    Zajacek (post-doc, 0.5 FTE), supervised by Prof. Bożena CzernyFY23: new hire (post-doc,
+    0.5 FTE), supervised by Prof. Bożena Czerny'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SER-SAG-S1.yaml
+++ b/docs/contribution-types/_data/software/SER-SAG-S1.yaml
@@ -40,6 +40,17 @@ form_data:
     this, the SER-SAG staff will train early with any Rubin tutorials provided, and be active
     participants in events associated with the Rubin “Data Previews”, all within the context
     of the AGN and TVS SC.
+  timeline: 'FY22: Dr. Andjelka Kovacevic (senior dedicated to software code development,
+    0.5 FTE), Viktor Radovic (postdoc 0.3 FTE), Dr. Mladen Nikolic (software engineer, 0.1
+    FTE), FY23: Dr. Andjelka Kovacevic (senior dedicated to software code development 0.5
+    FTE), Viktor Radovic (postdoc 0.3 FTE), Dr. Mladen Nikolic (software engineer, 0.1 FTE),FY24:
+    Dr. Viktor Radovic (postdoc, 0.5 FTE), Dr. Mladen Nikolic (software engineer, 0.1 FTE)
+    FY25: Dr. Viktor Radovic(postdoc, 0.5 FTE), Dr. Mladen Nikolic (software engineer, 0.1
+    FTE), FY26: New hire postdoc (0.5 FTE), Dr. Mladen Nikolic (software engineer, 0.1 FTE)FY27-FY35:
+    potential continued contribution of development effort.Dr. Andjelka Kovacevic will act
+    as a single point of contact with the recipients for this programme, but the other team
+    members will also be embedded within the recipient teams. From FY24, Dr Viktor Radovic
+    will become a single point of contact.'
   submitted: true
   email: andjelka.kovacevic@matf.bg.ac.rs
   submitter_name: Andjelka Kovacevic

--- a/docs/contribution-types/_data/software/SER-STG-S1.yaml
+++ b/docs/contribution-types/_data/software/SER-STG-S1.yaml
@@ -26,6 +26,13 @@ form_data:
     We also acted as a proxy for LSST in a very successful EU COST action “Big data in Sky
     and Earth Observations.”Members of our team are involved in LSST TVS and DESC Science
     Collaborations.
+  timeline: 'FY15: Prof. Darko Jevremović, (0.2 FTE), Mr. Veljko Vujčić (software engineer,
+    0.1 FTE)FY16: Prof. Darko Jevremović, (0.2 FTE), Mr. Veljko Vujčić (software engineer,
+    0.1 FTE), rest of the team 0.2 FTEFY17: Prof. Darko Jevremović, (0.2 FTE), Mr. Veljko
+    Vujčić (software engineer, 0.1 FTE)FY18: Prof. Darko Jevremović, (0.1 FTE), Mr. Veljko
+    Vujčić (software engineer, 0.1 FTE)FY19: Prof. Darko Jevremović, (0.1 FTE), Mr. Veljko
+    Vujčić (software engineer, 0.1 FTE)FY20: Prof. Darko Jevremović, (0.2 FTE), Mr. Veljko
+    Vujčić (software engineer, 0.1 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SLO-UNG-S2.yaml
+++ b/docs/contribution-types/_data/software/SLO-UNG-S2.yaml
@@ -21,6 +21,9 @@ form_data:
     this, the UNG staff will engage early with any Rubin tutorials provided, and look to be
     active participants in events associated with the Rubin “Data Previews”, all within the
     context of the TVS SC.'
+  timeline: 'FY22: Dr. Mile Karlica (postdoc, 0.5 FTE)FY23: Dr. Mile Karlica (postdoc, 0.5
+    FTE)Or FY22: Dr. Mile Karlica (postdoc, 0.5 FTE), Dr. Saptashwa Bhattacharyya (postdoc,
+    0.5 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SWE-STK-S1.yaml
+++ b/docs/contribution-types/_data/software/SWE-STK-S1.yaml
@@ -28,6 +28,10 @@ form_data:
     early with any Rubin and LSST DESC tutorials provided, engage with DESC Data Challenges,
     and look to be active participants in events associated with the Rubin “Data Previews”,
     all within the context of LSST DESC.'
+  timeline: 'FY22: New hire (software engineer, 0.5 FTE)FY23: New hire (software engineer,
+    0.5 FTE)FY24: New hire (software engineer, 0.5 FTE), New hire (postdoc, 0.5 FTE)FY25:
+    New hire (postdoc, 0.5 FTE) FY26: New hire (postdoc, 0.5 FTE)FY27-FY35: potential continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SWE-STK-S2.yaml
+++ b/docs/contribution-types/_data/software/SWE-STK-S2.yaml
@@ -17,6 +17,9 @@ form_data:
     on progress, taking input from the rest of the collaboration, and supporting the collaboration’s
     members in the use of the code. This summary of past contributions was developed in consultation
     with DESC.
+  timeline: 'FY17: Dr Rahul Biswas (postdoc, 0.2 FTE at 40% effort over half the year)FY18:
+    Dr Rahul Biswas (postdoc, 0.6 FTE)FY19: Dr Rahul Biswas (postdoc, 0.3 FTE)FY20: Dr Rahul
+    Biswas (postdoc, 0.2 FTE at 40% effort over half the year)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SWI-EPF-S1.yaml
+++ b/docs/contribution-types/_data/software/SWI-EPF-S1.yaml
@@ -38,6 +38,27 @@ form_data:
     We will work along these lines for any work done in the context of the present proposal.
     This contribution has been endorsed by the Strong Lensing Science Collaboration and the
     Dark Energy Strong Lensing Science Collaboration.'
+  timeline: 'The plan below is only tentative, but provides a global idea of the expected
+    progress. All proposed tasks correspond to new or updates freely available APIs. FY22:
+    Cameron Lemon (postdoc, 0.2 FTE), G. Vernardos (postdoc, 0.2 FTE) + supporting effort
+    from the PI In this initial phase the database would contain the basic information for
+    galaxy-scale lenses, such as position, grade, redshift information, if available, and
+    methods used to find or re-discover any given lens or candidate. Work should be done in
+    direct collaboration with LSST working groups to ensure formatting is compatible with
+    needs. FY23: Cameron Lemon (postdoc, 0.1 FTE), G. Vernardos (postdoc, 0.1 FTE) +supporting
+    effort from the PI In this phase the goal is to ingest further information in the database
+    for galaxy-scale lenses: ancillary data fetched from other databases and basic lens models.
+    Link to the complete literature for all objects.FY24: Cameron Lemon (postdoc, 0.1 FTE)
+    + 0.1 FTE from another postdoc (TBD) + supporting effort from the PI Start to include
+    time dimension, more evolved lens models, link to ESAsky, start to make the LSST and Euclid
+    data models compatible and ready to be merged at some point when decided by the two consortia.
+    Include lensing by clusters and arcs, arclets grouped by image and counter-image.FY25-FY35:
+    0.1 FTE per year for postdocs to maintain, document, update the database and increase
+    LSST strong lensing science. At this stage the database is assumed to include all known
+    galaxy-scale lenses and all false positives. False positives should ideally be classified
+    in subclasses, e.g. spirals, ring-galaxies, mergers, etc… Work on deblending and interaction
+    with photo-z group for refined determination of photo-z for lens and source. Include more
+    extensive lens models, including error bars on lens parameters.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SWI-ETH-S1.yaml
+++ b/docs/contribution-types/_data/software/SWI-ETH-S1.yaml
@@ -26,6 +26,8 @@ form_data:
     developer will engage early with any DESC and Rubin tutorials provided, and look to be
     active participants in events associated with the Rubin “Data Previews” and DESC data
     challenges, all within the context of DESC.
+  timeline: 'FY22: software developer to be hired 0.5 FTEFY23: software developer to be hired
+    0.5 FTETotal: 1 FTE'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SWI-ETH-S2.yaml
+++ b/docs/contribution-types/_data/software/SWI-ETH-S2.yaml
@@ -15,6 +15,12 @@ form_data:
     at the needed scale. We avoid risks associated with gaining the needed expertise in the
     Rubin/DESC tools and data products as one member of our staff has already been working
     in the pipeline scientists role.
+  timeline: 'Here, we assume that the fiscal year starts on October 1st of each year. We plan
+    to conclude this contribution at the end of FY26 (September 30th, 2026). We also note
+    that Dr. Andrade-Oliveira was on sick leave for some time in FY24 and FY25. FY24: Dr.
+    Felipe Andrade-Oliveira (postdoc, 0.20 FTE)FY25: Dr. Felipe Andrade-Oliveira (postdoc,
+    0.10 FTE)FY26: Dr. Felipe Andrade-Oliveira (postdoc, 0.35 FTE), Dr. David Sanchez-Cid
+    (postdoc, 0.35 FTE)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SZA-SAA-S2.yaml
+++ b/docs/contribution-types/_data/software/SZA-SAA-S2.yaml
@@ -36,6 +36,17 @@ form_data:
     software over the lifetime of LSST. The Galaxies Science Collaboration endorses the creation
     of high-level data products from the MeerKAT science archive to facilitate LSST galaxy
     evolution science.
+  timeline: 'FY22-FY23: Development of MeerKAT processing pipeline to produce the contributed
+    dataset; development of services (sophisticated cross matching; cutouts; overlays, etc.)
+    that can be deployed within the Rubin Science Platform (effort throughout this period:
+    0.2 FTE/yr from contribution lead, 0.5 FTE/yr from skilled postdoc [to be hired]).FY23-FY25:
+    Routine processing of MeerKAT data as it becomes available; initial deployment at NOIRLab;
+    regular updates to products hosted at NOIRLab to match up with the LSST Data Release schedule
+    (effort throughout this period: 0.2 FTE/yr from contribution lead; effort for FY23-24:
+    0.5 FTE/yr from skilled postdoc [to be hired]; we will seek additional postdoc support
+    every 3-year funding cycle).FY25-FY34: Ongoing support and maintenance of software, services,
+    and data products (effort throughout this period: 0.2 FTE/yr and/or as required by the
+    contribution lead, who is happy to provide long term support).'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/SZA-SAA-S3.yaml
+++ b/docs/contribution-types/_data/software/SZA-SAA-S3.yaml
@@ -33,6 +33,11 @@ form_data:
     in terms of which project is higher priority and what additional features are required.DESC
     has endorsed this contribution in an email exchange between Phil Marshall and Rachel Mandelbaum
     (spokesperson of DESC).
+  timeline: 'FY17: Dr. Michelle Lochner (researcher, 0.1 FTE)FY18: Dr. Michelle Lochner (researcher,
+    0.1 FTE)FY19: Dr. Michelle Lochner (researcher, 0.1 FTE)FY20: Dr. Michelle Lochner (senior
+    lecturer, 0.1 FTE)FY21: Dr. Michelle Lochner (senior lecturer, 0.1 FTE)FY22-FY26: Dr.
+    Michelle Lochner (senior lecturer, 0.5 FTE over 5 years for DESC-guided software development
+    and maintenance)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/TAI-ASI-S4.yaml
+++ b/docs/contribution-types/_data/software/TAI-ASI-S4.yaml
@@ -28,6 +28,19 @@ form_data:
     ApJ, 894, 125). Most importantly, Dr. Jain has written a cluster detection code in fortran
     called pFOF (Probability Friends-Of-Friends; Jian et al. 2014, 788, 109) that can be applied
     to data coming from the LSST, taking photo-z of galaxies as the main input.
+  timeline: 'FY22: Dr. Bau-Ching Hsieh (0.5 FTE), Dr. Hung-Yu Jian (0.5 FTE)FY23: Dr. Bau-Ching
+    Hsieh (0.5 FTE for DR1 and DR2), Dr. Hung-Yu Jian (0.4 FTE for DR1 and DR2)FY24: Dr. Bau-Ching
+    Hsieh (0.1 FTE), Dr. Hung-Yu Jian (0.1 FTE to further optimize the cluster detection parameters)FY25:
+    Dr. Bau-Ching Hsieh (0.1 FTE), Dr. Hung-Yu Jian (0.1 FTE: if Rubin-Euclid dataset is available,
+    a new cluster catalog would be generated; otherwise the efforts would be concentrated
+    on clusters in Deep Drilling fields, as well as to refine the membership assignment) FY26:
+    Dr. Bau-Ching Hsieh (0.1 FTE)FY27: Dr. Bau-Ching Hsieh (0.1 FTE)FY28: Dr. Bau-Ching Hsieh
+    (0.1 FTE), Dr. Hung-Yu Jian (0.1 FTE: if Rubin-Roman dataset is available, a new cluster
+    catalog would be generated; otherwise the effort would be an update of cluster catalog
+    based on much deeper data than DR3/DR4)FY29: Dr. Bau-Ching Hsieh (0.1 FTE)FY30: Dr. Bau-Ching
+    Hsieh (0.1 FTE)FY31: Dr. Bau-Ching Hsieh (0.1 FTE)FY32: Dr. Bau-Ching Hsieh (0.1 FTE),
+    Dr. Hung-Yu Jian (0.1 FTE)In total, Dr. Hsieh will contribute 1.9 FTE, while Dr. Jian
+    will contribute 1.3 FTE, over 11 years.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-OXF-S1.yaml
+++ b/docs/contribution-types/_data/software/UKD-OXF-S1.yaml
@@ -31,6 +31,10 @@ form_data:
     development and validation of these software packages will require access to HPC facilities.
     The resources available at the Oxford Astrophysics Small Research Facility (to which we
     have unrestricted access), as well as access to NERSC should be sufficient for this work.'
+  timeline: 'FY15-FY20: David Alonso (1 FTE)[1]FY21: Carlos Garcia (Beecroft fellow, 0.5 FTE)FY22:
+    Carlos Garcia (Beecroft fellow, 0.5 FTE)FY23: New hire (postdoc/software engineer, 0.5
+    FTE)FY24: New hire (postdoc/software engineer, 0.5 FTE)FY25-FY35: potential continued
+    contribution of development effort.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-OXF-S4.yaml
+++ b/docs/contribution-types/_data/software/UKD-OXF-S4.yaml
@@ -36,6 +36,9 @@ form_data:
     the potential to identify lensed transients from early survey data. We aim to have the
     infrastructure in place for commissioning/early science to test and then demonstrate the
     efficacy of the system and then improve, refine, optimise the capability as required.
+  timeline: 'FY22: New hire (postdoc/software engineer, 0.5 FTE)FY23: New hire (postdoc/software
+    engineer, 0.5 FTE)FY24: New hire (postdoc/software engineer, 0.5 FTE)FY25-FY34: potential
+    continued contribution and/or 0.1FTE maintenance will be sought.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S10.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S10.yaml
@@ -38,6 +38,8 @@ form_data:
     this contribution. We note the latter is on the condition that TVS members will be kept
     informed in a timely manner of all information relevant to these surveys. This is our
     plan, and we are happy to accept that condition.'
+  timeline: 'FY21: 1 FTE software developer for 0.5 yrs FY22: 1 FTE software developer for
+    1.0 yrs FY23: 1 FTE software developer for 1.0 yrs'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S11.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S11.yaml
@@ -32,6 +32,9 @@ form_data:
     work in galaxy surveys, and are currently gaining experience with COVID-era hires and
     work models. We will also invite additional DESC management personnel onto the recruitment
     panel.
+  timeline: 'FY21: New hire (postdoc, 0.75 FTE)FY22: New hire (postdoc, 1 FTE)FY23: New hire
+    (postdoc, 0.75 FTE)FY23++: potential continued contribution of software development and
+    DESC data processing effort'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S12.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S12.yaml
@@ -34,6 +34,15 @@ form_data:
     This has begun during LUSC Phase B, with a process based around six-monthly plans, so
     we propose that this should be the mechanism through which funded staff are redirected,
     with new six-monthly plans agreed between the Recipient Group and the local supervisor.
+  timeline: 'FY2023 : 7 FTE for 0.5 yr (April - September) funded in LSST:UK Phase C FY2024
+    : 7 FTE for 1.0 yr funded in LSST:UK Phase C FY2025 : 7 FTE for 1.0 yr funded in LSST:UK
+    Phase C FY2026 : 7 FTE for 1.0 yr funded in LSST:UK Phase C FY2027 : 7 FTE for 0.5 yr
+    (October to March) funded in LSST:UK Phase C FY2028 : 1 FTE for 0.5 yr (April to September)
+    funded in LSST:UK Phase D FY2029 : 1 FTE for 1 yr funded in LSST:UK Phase DFY2030 : 1
+    FTE for 1 yr funded in LSST:UK Phase D FY2031 : 1 FTE for 1 yr funded in LSST:UK Phase
+    D FY2032 : 1 FTE for 1 yr funded in LSST:UK Phase D FY2033 : 1 FTE for 1 yr funded in
+    LSST:UK Phase D FY2034 : 1 FTE for 0.5 yr (April to September) funded in LSST:UK Phase
+    D'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S16.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S16.yaml
@@ -35,6 +35,12 @@ form_data:
     Software Roadmap (Schwamb et al. 2019). The SSSC supports this contribution and welcomes
     the flexibility to use Adler on the RSP and IDACs for an individual small body or with
     Lasair running automatically in bulk on all incoming Solar System alerts.
+  timeline: 'FY23-FY24: Jamie Robinson [Edinburgh] (postdoc, 1 FTE)/Steph Merritt [QUB] (postdoc,
+    1 FTE); FY24/25: Adler 1.0 release: Development of core small body/comet functions analysing
+    Solar System alert data with Lasair front-end and back-end integration; FY24-FY25: 2.0
+    FTE Postdoc staff years of effort ; FY25/26 Adler 2.0: Multi-year functionality added
+    with Lasair integration, comparing phase curves from different years, brightness/activity
+    between perihelion passage, and incorporating data releases/multi-year prompt data products.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S17.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S17.yaml
@@ -32,6 +32,8 @@ form_data:
     to test and compare standard SI decontamination methods. LSST:UK will generate vital products
     for any clustering measurements made by the DESC and the GSC: random catalogs, masks,
     systematic maps.'
+  timeline: 'Deliverable A: 04/2024; Deliverable B: 04/2025; Deliverable C: 04/2026; Deliverable
+    D: 04/2027'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S6.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S6.yaml
@@ -37,6 +37,9 @@ form_data:
     resources to interpret the results. We do not anticipate a change in our resource needs.
     The primary risk is gaining an understanding of the DM pipeline architecture. However,
     our close and ongoing interaction with the DM team mitigates this.
+  timeline: 'FY20: Dr Aaron Watkins (postdoc, 1 FTE for 0.5 years, Mar 20 - Sep 20)FY21: Dr
+    Aaron Watkins (postdoc, 1 FTE)FY22: Dr Aaron Watkins (postdoc, 1 FTE)FY23 : Dr Aaron Watkins
+    (postdoc, 1 FTE for 0.5 years)'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S8.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S8.yaml
@@ -21,6 +21,14 @@ form_data:
     an existing GridPP grant. All software developed by the team will be public, in accordance
     with the proposed DESC software policy.This proposal has been developed in consultation
     with DESC. The past contribution FY19-FY20 has been endorsed by DESC.
+  timeline: 'We note that Zuntz and Perry have been working in these roles within DESC since
+    2019 FY 20: Dr Joe Zuntz (Faculty, 0.3 FTE), Dr James Perry (HPC Professional 0.5 FTE)
+    + 2.005 million CPU hours on the UK’s GridPP system for DESC simulated images. FY 21:
+    Dr Joe Zuntz (Faculty, 0.3 FTE), Dr James Perry (HPC Professional 0.5 FTE)FY 22: Dr Joe
+    Zuntz (Faculty, 0.3 FTE), Dr James Perry (HPC Professional 0.25 FTE)FY23 : Dr Joe Zuntz
+    (Faculty, 0.15 FTE)FY23-FY35: potential continued contribution of development effort.
+    There is potential for this effort to continue beyond August 2023 and this will be presented
+    as an overall UK contribution in FTE yrs in UKD-UKD-12.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/_data/software/UKD-UKD-S9.yaml
+++ b/docs/contribution-types/_data/software/UKD-UKD-S9.yaml
@@ -36,6 +36,9 @@ form_data:
     producing cross-match tables between the entirety of the LSST and the other surveys. The
     compute time required to build the tables will be provided through the UK IDAC computing
     resource as described in S3.
+  timeline: 'FY20: Dr. Tom Wilson (postdoc, 0.8 FTE).FY21: Dr. Tom Wilson (postdoc 1.0 FTE)FY22:
+    Dr. Tom Wilson (postdoc 0.7 FTE)FY23-FY35: Potential contribution of software maintenance
+    effort and running.'
   submitted: false
   email: null
   submitter_name: null

--- a/docs/contribution-types/contributed-software.rst
+++ b/docs/contribution-types/contributed-software.rst
@@ -6,7 +6,7 @@ The Vera C. Rubin Observatory In-Kind Program includes contributed software: dir
 This page lists all current software-development contributions. General pool contributions -- directable effort offered without a recipient defined ahead of time -- are listed on the :doc:`general-pool` page instead.
 
 Use the filters or the table below to browse by category, science keyword, or recipient group.
-Each entry starts with the basics from the original proposal; cards marked *Delivered* have a full team-submitted record on file, and cards marked *Pending* are still awaiting that submission.
+Each entry starts with the basics from the original proposal; cards marked *Delivered* have a full team-submitted record on file, and cards marked *In Progress* are still awaiting that submission.
 Some software contributions also produce a dataset -- where that's the case, the card links to the matching entry on the :doc:`contributed-datasets` page.
 
 Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have any questions about contributed software.
@@ -59,7 +59,7 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
           <select id="ikc-sw-filter-status">
             <option value="">All</option>
             <option value="status-delivered">Delivered</option>
-            <option value="status-pending">Pending</option>
+            <option value="status-pending">In Progress</option>
           </select>
         </label>
       </div>
@@ -89,7 +89,7 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
             <td><button type="button" class="ikc-title-link" data-cid="{{ item.cid_slug }}">{{ item.title }} ({{ item.contribution_id }})</button></td>
             <td>{{ item.form_data.category or 'TBD' }}</td>
             <td>{{ item.form_data.primary_recipient_group or 'TBD' }}</td>
-            <td>{% if item.status == 'delivered' %}<span class="ikc-badge ikc-badge-success">Delivered</span>{% else %}<span class="ikc-badge ikc-badge-muted">Pending</span>{% endif %}</td>
+            <td>{% if item.status == 'delivered' %}<span class="ikc-badge ikc-badge-success">Delivered</span>{% else %}<span class="ikc-badge ikc-badge-muted">In Progress</span>{% endif %}</td>
             <td>{{ item.last_updated or 'unknown' }}</td>
           </tr>
           {% endfor %}
@@ -205,6 +205,12 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
 
           {% if item.form_data.software_name %}**Software:** {{ item.form_data.software_name }}{% endif %}
 
+          {% if item.approx_start %}**Start (approx.):** {{ item.approx_start }}{% endif %}
+
+          {% if item.software_links %}**Links:** {% for link in item.software_links %}`{{ link.label }} <{{ link.url }}>`__{{ ", " if not loop.last else "" }}{% endfor %}{% endif %}
+
+          {% if item.documentation_links %}**Documentation:** {% for link in item.documentation_links %}`{{ link.label }} <{{ link.url }}>`__{{ ", " if not loop.last else "" }}{% endfor %}{% endif %}
+
           .. raw:: html
 
              <div class="ikc-desc">{{ item.form_data.activity_description or 'TBD' }}</div>
@@ -223,5 +229,5 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
 
           *Updated: {{ item.last_updated or 'unknown' }}*
           +++
-          {% if item.status == 'delivered' %}:bdg-success:`Delivered`{% else %}:bdg-muted:`Pending`{% endif %}
+          {% if item.status == 'delivered' %}:bdg-success:`Delivered`{% else %}:bdg-muted:`In Progress`{% endif %}
       {% endfor %}

--- a/scripts/sync_software_contributions.py
+++ b/scripts/sync_software_contributions.py
@@ -6,7 +6,10 @@ Two inputs:
                      columns: Country, Institute, ID, Contribution Title,
                      Scraped Recipient Group, SOW, Timeline, Category,
                      Recipient Group(s), Primary Recipient Group,
-                     Activity Description)
+                     Activity Description). Timeline is a free-text
+                     FTE-by-fiscal-year narrative, not a clean date -- it's
+                     carried through as-is and the page derives a rough
+                     "first FY mentioned" indicator from it.
   --form-responses  the "In-kind Contribution Resources" Google Form export,
                      shared with the Datasets page's intake. Only rows whose
                      "Contribution deliverable type" is Software are used
@@ -131,6 +134,10 @@ def load_contributions(path):
             "primary_recipient_group": primary,
             "additional_recipient_groups": additional,
             "activity_description": normalize_ws(row[10]),
+            # Free-text FTE-by-fiscal-year narrative, not a clean date --
+            # the page derives a rough "first FY mentioned" indicator from
+            # this, see conf.py's _approx_start_fy().
+            "timeline": normalize_ws(row[6]),
         }
     return records
 
@@ -276,6 +283,7 @@ def default_form_data(row):
         "primary_recipient_group": row["primary_recipient_group"],
         "additional_recipient_groups": row["additional_recipient_groups"],
         "activity_description": row["activity_description"],
+        "timeline": row["timeline"],
         "submitted": False,
         "email": None,
         "submitter_name": None,


### PR DESCRIPTION
Three follow-ups on the Contributed Software page (#44):

1. Renamed the "Pending" status label to "In Progress" everywhere it's shown.
2. Cards now show clickable links for the software URL and documentation fields, instead of unlinked text -- fixes SER-SAG-S1's card having no link to its repository.
3. Added an approximate "Start" field to cards, derived from the proposal spreadsheet's free-text Timeline column (first fiscal year mentioned -- there's no clean start-date field in the source data).