### PR TITLE
Add interactive Computing Resources (IDAC/SPC) dashboard

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -744,3 +744,140 @@ def _collect_cross_page_titles(subdir_name):
 
 
 jinja_contexts["contributed_software"] = _load_contributed_software()
+
+
+# ============================================================================
+# APPEND THIS BLOCK TO conf.py (at the repo root), after the existing
+# `jinja_contexts["contributed_software"] = _load_contributed_software()` line.
+#
+# It reuses helpers already defined earlier in conf.py:
+#   _slugify, _normalize_strings, _to_marker_xy,
+#   _offset_clustered_markers, _load_world_outline_path
+# ============================================================================
+
+# ============================================================================
+# Contributed Computing Resources (IDAC / SPC) page data loading
+#
+# Each record lives as a YAML file in
+# docs/contribution-types/_data/idacs/<slug>.yaml. Like the telescopes page,
+# the In-kind coordinator is the source of truth (there is no external form
+# intake), so there is no form_data/curated split -- just a flat, hand-curated
+# schema. This loader reuses the equirectangular _to_marker_xy() projection and
+# the world-outline SVG from the telescopes loader above, sizes each marker by
+# its storage commitment, and exposes everything to contributed-resources.rst
+# via sphinx_jinja.
+# ============================================================================
+
+_IDAC_PRODUCT_LABELS = {
+    "object_table_subset": "Object Table (subset)",
+    "object_table": "Object Table",
+    "source_table": "Source Table",
+    "forced_source_table": "ForcedSource Table",
+    "dia_object_table": "DIAObject Table",
+    "dia_source_table": "DIASource Table",
+    "solar_system_tables": "Solar System Tables",
+    "co_added_images": "Co-added Images",
+    "visit_images": "Visit Images",
+    "difference_images": "Difference Images",
+    "template_images": "Template Images",
+    "other_data_products": "Other Data Products",
+}
+
+
+def _idac_marker_radius(storage, max_storage):
+    """Scale a marker radius by the square root of the storage commitment so
+    the map echoes the relative scale of each IDAC (bounded so the smallest
+    contributions stay clickable and the largest don't swamp the map)."""
+    if not storage or not max_storage:
+        return 4.0
+    return round(4.0 + 8.0 * (storage / max_storage) ** 0.5, 1)
+
+
+def _load_contributed_idacs():
+    data_dir = (
+        Path(__file__).parent
+        / "docs"
+        / "contribution-types"
+        / "_data"
+        / "idacs"
+    )
+    records = []
+    all_types = set()
+    all_products = set()
+
+    raw = []
+    for path in sorted(data_dir.glob("*.yaml")):
+        with path.open(encoding="utf-8") as f:
+            record = yaml.safe_load(f) or {}
+        record = _normalize_strings(record)
+        record["slug"] = _slugify(record.get("slug") or path.stem)
+        raw.append((path, record))
+
+    max_storage = max(
+        ((r.get("capacity") or {}).get("storage_pb_years") or 0) for _, r in raw
+    ) if raw else 0
+
+    for path, record in raw:
+        loc = record.get("location") or {}
+        lat, lng = loc.get("lat"), loc.get("lng")
+        if lat is not None and lng is not None:
+            record["marker_x"], record["marker_y"] = _to_marker_xy(lat, lng)
+        else:
+            record["marker_x"] = record["marker_y"] = None
+
+        cap = record.get("capacity") or {}
+        record["marker_r"] = _idac_marker_radius(cap.get("storage_pb_years"), max_storage)
+
+        idac_type = record.get("idac_type") or "IDAC"
+        record["idac_type"] = idac_type
+        all_types.add(idac_type)
+
+        products = record.get("data_products") or {}
+        hosted = [
+            _IDAC_PRODUCT_LABELS[k]
+            for k in _IDAC_PRODUCT_LABELS
+            if products.get(k)
+        ]
+        record["hosted_products"] = hosted
+        record["product_count"] = len(hosted)
+        record["product_total"] = len(_IDAC_PRODUCT_LABELS)
+        all_products.update(hosted)
+
+        # Space-separated CSS-safe tokens the page's filter script matches
+        # table rows, cards, and map markers against.
+        tokens = [f"type-{_slugify(idac_type)}", f"cid-{record['slug']}"]
+        tokens += [f"product-{_slugify(p)}" for p in hosted]
+        if cap.get("gpu_mhrs"):
+            tokens.append("has-gpu")
+        record["filter_tokens"] = " ".join(tokens)
+
+        search_parts = [
+            record.get("country", ""),
+            loc.get("city", "") or "",
+            loc.get("institution", "") or "",
+            idac_type,
+            record.get("software_services", "") or "",
+            record.get("use_cases", "") or "",
+            record.get("complementary_datasets", "") or "",
+            record.get("science_collaboration_agreements", "") or "",
+            *hosted,
+        ]
+        record["search_text"] = " ".join(p for p in search_parts if p).lower()
+        records.append(record)
+
+    _offset_clustered_markers([r for r in records if r.get("marker_x") is not None])
+    records.sort(key=lambda r: r.get("country", ""))
+    search_index = {r["slug"]: r["search_text"] for r in records}
+
+    return {
+        "idacs": records,
+        "all_types": sorted(all_types),
+        "all_products": sorted(all_products),
+        "product_labels": _IDAC_PRODUCT_LABELS,
+        "slugify": _slugify,
+        "search_index_json": json.dumps(search_index),
+        "world_outline_path": _load_world_outline_path(),
+    }
+
+
+jinja_contexts["contributed_idacs"] = _load_contributed_idacs()

--- a/docs/contribution-types/_data/idacs/argentina.yaml
+++ b/docs/contribution-types/_data/idacs/argentina.yaml
@@ -1,0 +1,88 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Argentina
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Argentina IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Argentina"
+slug: "argentina"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "La Plata"
+  institution: "Facultad de Ciencias Astronómicas (UNLP)"
+  lat: -34.908
+  lng: -57.953
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      null
+  free_storage_pb_years: 2
+  cpu_mhrs:              null
+  free_cpu_mhrs:         null
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  null
+  expected_local_users:  null
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  hipsdb tables for fast search and cross matching. image stamps DIA analysis. Mask and global properties maps for sample selection
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  user generated dataproducts, selected transients and variable data from follow-ups datasets
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Fast Correlation functions and cross-matching.
+  Voids and Systems of Galaxies detection and classification.
+  Streams and MW Satellite galaxies detection.
+  DIA algorithms for heterogeneous transient follow-ups.
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: |
+

--- a/docs/contribution-types/_data/idacs/australia.yaml
+++ b/docs/contribution-types/_data/idacs/australia.yaml
@@ -1,0 +1,84 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Australia
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Australia IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Australia"
+slug: "australia"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Melbourne"
+  institution: "Swinburne University"
+  lat: -37.8199
+  lng: 145.03586
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      20
+  free_storage_pb_years: 12.7
+  cpu_mhrs:              65
+  free_cpu_mhrs:         63.6
+  gpu_mhrs:              65
+  free_gpu_mhrs:         63.6
+  hosted_data_pb_years:  6.5
+  expected_local_users:  26
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Multipurpose science platform, with Slurm for job scheduling, EasyBuild for software modules, Lustre for storage
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  Local copy of LIGO data, MeerKAT SKA pulsar timing data, Gaia, MWA, etc.
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Cross-match LSST catalog objects with those from other optical (e.g. ESO, AAT) and radio survey (e.g. MWA)  data held
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/brazil.yaml
+++ b/docs/contribution-types/_data/idacs/brazil.yaml
@@ -1,0 +1,92 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Brazil
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Brazil IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Brazil"
+slug: "brazil"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Rio de Janeiro"
+  institution: "LIneA"
+  lat: -22.953
+  lng: -43.176
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      65
+  free_storage_pb_years: 65
+  cpu_mhrs:              56
+  free_cpu_mhrs:         54.8
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  6.5
+  expected_local_users:  26
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  LIneA Science Platform (LSP) with Jupyter notebooks, combining upgraded science server as deployed at NCSA with new user query (based on Daiquiri platform) and x-match service (based on LDSB); photo-z server, solar system portal, cluster analysis and visualization server (CANVAS); HPC cluster (Slurm, Open OnDemand); PostgreSQL.
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  Survey property maps (e.g. masks; depth); photo-z tables, spectroscopic redshift samples, training sets; cluster and stellar system candidate list updated with each DR;  regularly updated list of occultation events; SDSS and DES object catalogs; all-sky hips image
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Photo-z's; galaxy clusters; resolved stars; visualization; crossmatches; occultation events
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  - name:  "Carlos Adean"
+    email: "carlosadean@linea.org.br"
+    role:  "Technical contact"
+  - name:  "Luiz Da Costa"
+    email: "ldacosta@linea.org.br"
+    role:  "Programmatic contacts"
+  - name:  "Julia Gschwend"
+    email: "julia@linea.org.br"
+    role:  "Programmatic contacts"
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/canada.yaml
+++ b/docs/contribution-types/_data/idacs/canada.yaml
@@ -1,0 +1,110 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Canada
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Canada IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Canada"
+slug: "canada"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Victoria"
+  institution: "Canadian Astronomy Data Centre (NRC Herzberg)"
+  lat: 48.519
+  lng: -123.418
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  true
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      186
+  free_storage_pb_years: 186.4
+  cpu_mhrs:              630
+  free_cpu_mhrs:         473
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  138
+  expected_local_users:  150
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  CAOM interface, CANFAR science platform, Firefly/Rubin Portal, TAP, QServ/sharded DB, Multi-Messanger Alerts DB
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  SKA, Euclid, and CADC Archives
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: ""
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  - name:  "Ryan Taylor"
+    email: "rptaylor@uvic.ca"
+    role:  "Technical contacts"
+  - name:  "Stephen Gwyn"
+    email: "Stephen.Gwyn@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "Brian Major"
+    email: "Brian.Major@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "John Ouellette"
+    email: "John.Ouellette@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "JJ Kavelaars"
+    email: "JJ.Kavelaars@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "Sharon Goliath"
+    email: "Sharon.Goliath@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "Adrian Damian"
+    email: "Adrian.Damian@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "Pat Dowler"
+    email: "patrick.dowler@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+  - name:  "Isabella Ghiurea"
+    email: "Isabella.Ghiurea@nrc-cnrc.gc.ca"
+    role:  "Programmatic contacts"
+
+# === Free-text notes ======================================================
+notes: |
+  Includes support for public archive

--- a/docs/contribution-types/_data/idacs/croatia.yaml
+++ b/docs/contribution-types/_data/idacs/croatia.yaml
@@ -1,0 +1,87 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Croatia
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Croatia IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Croatia"
+slug: "croatia"
+idac_type: "SPC"
+
+location:
+  city:        "Rijeka"
+  institution: "Bura supercomputer, University of Rijeka"
+  lat: 45.327
+  lng: 14.442
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  false
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      9
+  free_storage_pb_years: 7.7
+  cpu_mhrs:              30
+  free_cpu_mhrs:         29.7
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  1.3
+  expected_local_users:  7
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Access through secure VPN channel & IP filtering (need to be arranged in advance)
+  OS Redhat, command prompt + Slurm workload manager, MPI for parallel computing, conda environment
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: ""
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Stellar astrophysics, including period finding, TRILEGAL Milky Way simulation, and microlensing light curves
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: |
+  Solar System (May 2026)
+  Transients and Variable Stars (pending)
+  Stars Milky Way and Local Volume (pending)
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/denmark.yaml
+++ b/docs/contribution-types/_data/idacs/denmark.yaml
@@ -1,0 +1,85 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Denmark
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Denmark IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Denmark"
+slug: "denmark"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Copenhagen"
+  institution: "DARK / Niels Bohr Institute"
+  lat: 55.696
+  lng: 12.57
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     true
+  solar_system_tables:  false
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      65
+  free_storage_pb_years: 11.7
+  cpu_mhrs:              280
+  free_cpu_mhrs:         265.8
+  gpu_mhrs:              1
+  free_gpu_mhrs:         0.5
+  hosted_data_pb_years:  53
+  expected_local_users:  60
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  TBD
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  Community-derived data products; Auxiliary data products relevant for transient + galaxy science such as SDSS, PS, WISE, VEXAS, KIDS, GALEX, Euclid
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Special emphasis on transients, cosmology, galaxies, dark matter (serving especially DESC, TVS, SLS); AI/ML applications
+  Rubin/Euclid joint processing
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/japan.yaml
+++ b/docs/contribution-types/_data/idacs/japan.yaml
@@ -1,0 +1,86 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Japan
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Japan IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Japan"
+slug: "japan"
+idac_type: "Lite IDAC (x2)"
+
+location:
+  city:        "Mitaka, Tokyo"
+  institution: "National Astronomical Observatory of Japan (NAOJ) and Kavli IPMU"
+  lat: 35.675
+  lng: 139.541
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  true
+  dia_object_table:     false
+  dia_source_table:     true
+  solar_system_tables:  false
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      46
+  free_storage_pb_years: 35.2
+  cpu_mhrs:              141
+  free_cpu_mhrs:         138.3
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  9.75
+  expected_local_users:  35
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Jupyter+Kubernetes platform built on HSC-SSP uses. Other interfaces such as Xpra desktop access and filesharing are under development. Database options include Postgresql, Citus, MapReduce distributed DB
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  HSC and PFS data
+  How much and what types of Rubin data to be hosted: under discussion
+  PFS spectra of transient, host galaxies and photo-z training sample taken by other in-kind contribution
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Weak lensing cosmology, transients (incl. SNe), photo-z's, solar system sciences
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/mexico.yaml
+++ b/docs/contribution-types/_data/idacs/mexico.yaml
@@ -1,0 +1,83 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Mexico
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Mexico IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Mexico"
+slug: "mexico"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Mexico City"
+  institution: "Universidad Nacional Autónoma de México (UNAM)"
+  lat: 19.3263
+  lng: -99.1762
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         true
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  false
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      20
+  free_storage_pb_years: 16
+  cpu_mhrs:              31
+  free_cpu_mhrs:         30.5
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  3.25
+  expected_local_users:  10
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Lustre file system, PostgreSQL, exploring RSP as interface
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: ""
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  TBD
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/poland.yaml
+++ b/docs/contribution-types/_data/idacs/poland.yaml
@@ -1,0 +1,84 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Poland
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Poland IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Poland"
+slug: "poland"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Poznań"
+  institution: "Poznań Supercomputing and Networking Center"
+  lat: 52.406
+  lng: 16.925
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      65
+  free_storage_pb_years: 57.3
+  cpu_mhrs:              56
+  free_cpu_mhrs:         54.8
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  6.5
+  expected_local_users:  26
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Dedicated multipurpose science platform (Jupyter/SSH/UI on SLURM/Lustre using Docker Swarm/Singularity/CVMFS/Keycloak/OpenSearch/…)
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  Local copies of Gaia, OGLE, SDSS, Vipers, Akari, other catalogs
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Rubin-Gaia cross-match, Rubin-OGLE-ZTF cross-match along the Milky Way disk, Rubin-OGLE-VMC-DECam cross-match for Magellanic System, Preparation of a catalog of known variable stars in the Rubin sky, Construction of deep color-color and color-magnitude diagrams for Magellanic Clouds, Data from alerts for microlensing, LSST large-scale structure (LSS) analysis, Photometric Redshift estimation of galaxies from the LSST data, Quasar redshift estimation and brightness curves, photometric redshift (PZ) estimation of galaxies
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/slovenia.yaml
+++ b/docs/contribution-types/_data/idacs/slovenia.yaml
@@ -1,0 +1,84 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Slovenia
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Slovenia IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Slovenia"
+slug: "slovenia"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Nova Gorica"
+  institution: "University of Nova Gorica"
+  lat: 45.9558
+  lng: 13.6461
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  false
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      7
+  free_storage_pb_years: 3.2
+  cpu_mhrs:              20
+  free_cpu_mhrs:         19.7
+  gpu_mhrs:              3.25
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  null
+  expected_local_users:  5
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  TBD
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  TBD
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  TBD
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  []  # TODO: add at least one contact
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/south-korea.yaml
+++ b/docs/contribution-types/_data/idacs/south-korea.yaml
@@ -1,0 +1,85 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- South Korea
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the South Korea IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "South Korea"
+slug: "south-korea"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Daejeon"
+  institution: "Korea Astronomy and Space Science Institute (KASI)"
+  lat: 36.398
+  lng: 127.388
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      true
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      7
+  free_storage_pb_years: 3.2
+  cpu_mhrs:              20
+  free_cpu_mhrs:         19.7
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  3.25
+  expected_local_users:  5
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Rubin-dedicated hyperconverged infrastructure cluster to host Rubin Science Platform (Portal/Notebooks/APIs) and distributed PostgreSQL databases for object-lite catalog. Additional high-capacity object storage to serve coadded images.
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  user-generated data products
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: ""
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  - name:  "Chang Hee Ree"
+    email: "chr@kasi.re.kr"
+    role:  null
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/spain.yaml
+++ b/docs/contribution-types/_data/idacs/spain.yaml
@@ -1,0 +1,104 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- Spain
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the Spain IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "Spain"
+slug: "spain"
+idac_type: "Lite IDAC"
+
+location:
+  city:        "Barcelona"
+  institution: "Port d'Informació Científica (PIC) / IFAE"
+  lat: 41.5
+  lng: 2.111
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         false
+  source_table:         false
+  forced_source_table:  false
+  dia_object_table:     false
+  dia_source_table:     false
+  solar_system_tables:  false
+  co_added_images:      false
+  visit_images:         false
+  difference_images:    false
+  template_images:      false
+  other_data_products:  false
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      7
+  free_storage_pb_years: 3.2
+  cpu_mhrs:              21
+  free_cpu_mhrs:         20.4
+  gpu_mhrs:              20
+  free_gpu_mhrs:         0.8
+  hosted_data_pb_years:  3.25
+  expected_local_users:  8
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  CosmoHub:
+  Web portal for interactive exploration and distribution of massive cosmological datasets
+  Full dataset plots (over all rows): May use sampling / Cone search tool / 1D histogram & 2D heatmap
+  TAP + ADQL interfaces in development
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  ~15 different projects (Gaia, DES, PAU, Euclid, DESI, COSMOS, KiDS, GLADE, CFHTLenS, ...)
+  including DESC DC2 (Object and Truth-match tables)
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Catalog validation / exploration / crossmatch
+  Large Scale Structure algorithms (photo-z, 2-point correlation functions, ...)
+  Galaxy simulations
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  - name:  "Jordi Delgado"
+    email: "jordidem@pic.es"
+    role:  "Technical contacts"
+  - name:  "Francesc Torradeflot"
+    email: "torradeflot@pic.es"
+    role:  "Technical contacts"
+  - name:  "Jorge Carretero"
+    email: "carretero@pic.es"
+    role:  "Programmatic contacts"
+  - name:  "Nacho Sevilla"
+    email: "ignacio.sevilla@ciemat.es"
+    role:  "Programmatic contacts"
+  - name:  "Pau Tallada"
+    email: "tallada@pic.es"
+    role:  "Programmatic contacts"
+
+# === Free-text notes ======================================================
+notes: ""

--- a/docs/contribution-types/_data/idacs/united-kingdom.yaml
+++ b/docs/contribution-types/_data/idacs/united-kingdom.yaml
@@ -1,0 +1,93 @@
+# ============================================================================
+# Rubin IDAC Capabilities -- United Kingdom
+# ----------------------------------------------------------------------------
+# This file is the source of truth for what the public IDAC dashboard shows
+# about the United Kingdom IDAC. Open a pull request with any change you want
+# published. See data/SCHEMA.md for field definitions.
+# ============================================================================
+
+country: "United Kingdom"
+slug: "united-kingdom"
+idac_type: "Data Facility (Full IDAC)"
+
+location:
+  city:        "Edinburgh"
+  institution: "Royal Observatory / UK Data Facility"
+  lat: 55.923
+  lng: -3.187
+
+# === Rubin data products that will be hosted at this IDAC =================
+data_products:
+  object_table_subset:  true
+  object_table:         true
+  source_table:         true
+  forced_source_table:  true
+  dia_object_table:     true
+  dia_source_table:     true
+  solar_system_tables:  true
+  co_added_images:      true
+  visit_images:         true
+  difference_images:    false
+  template_images:      true
+  other_data_products:  true
+
+# === Rubin data releases stored at this IDAC ==============================
+# List the planned data releases, e.g. ["DP1", "DR1", "DR2"]. Leave [] if TBD.
+data_releases: []
+
+# === Capacity (integrated over the 13-year IDAC lifetime) =================
+capacity:
+  storage_pb_years:      2005
+  free_storage_pb_years: 10.9
+  cpu_mhrs:              61
+  free_cpu_mhrs:         41.1
+  gpu_mhrs:              null
+  free_gpu_mhrs:         null
+  hosted_data_pb_years:  1989
+  expected_local_users:  437
+
+# === Hardware architecture (FREE-TEXT, please fill in) ====================
+# e.g. "AMD EPYC 9654 (Genoa), 384 cores/node" / "NVIDIA H100 80GB SXM5"
+hardware:
+  cpu_architecture: ""
+  gpu_architecture: ""
+  storage_type:     ""
+  network:          ""
+
+# === Software services & platform =========================================
+software_services: |
+  Full RSP deployment
+  Options to exploit technologies from ‘nearby’ programmes – such as SKA, Euclid, and Gaia
+  Rucio for distributed data management (tbc); Ctrl-BPS/ Parsl/ Slurm – batch processing for  HPC (tbc)
+
+# === Complementary / auxiliary datasets ===================================
+complementary_datasets: |
+  LSST-VISTA fused products; crossmatch catalogues for topical surveys, Edinburgh Wide-field Astronomy Unit survey catalogues (via TAP)
+
+# === Science use cases this IDAC specializes in ===========================
+use_cases: |
+  Full range of science cases
+  Co-location with Lasair Community Broker for transient science
+
+# === Science Collaboration agreements made ===========================
+science_collaboration_agreements: ""
+
+# === Onboarding & documentation links (please fill in) ====================
+documentation:
+  - title: "Onboarding guide"
+    url:   ""
+  - title: "Science platform / user portal"
+    url:   ""
+
+# === Contacts =============================================================
+contacts:
+  - name:  "George Beckett"
+    email: "george.beckett@ed.ac.uk"
+    role:  null
+  - name:  "Mike Read"
+    email: "mar@roe.ac.uk"
+    role:  null
+
+# === Free-text notes ======================================================
+notes: |
+  Free CPU capacity does not include the UK Data Facility's significant resources for supporting database queries of full copy of catalog data

--- a/docs/contribution-types/contributed-resources.rst
+++ b/docs/contribution-types/contributed-resources.rst
@@ -14,45 +14,256 @@ IDACs and SPCs will collectively provide access to CPUs, data storage, databases
 Who has proposed computing resource contributions?
 ==================================================
 
-The table below lists the IDACs and SPCs expected to be active during Rubin Operations.
+The map, filters, search, and table below list the IDACs and SPCs expected to be active during Rubin Operations.
+Click a country in the table, or a marker on the map, to jump to its full profile.
 
+.. jinja:: contributed_idacs
 
+   .. raw:: html
 
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Program       |Type                     |Contacts                                                                           |
-+==============+=========================+===================================================================================+
-|United Kingdom|Data Facility (Full IDAC)|Bob Mann, George Beckett                                                           |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Argentina     |Lite IDAC                |Mariano Dominguez, Diego Garcia                                                    |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Australia     |Lite IDAC                |Jarrod Hurley, Sarah Brough, Stuart Ryder                                          |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Brazil        |Lite IDAC                |Carlos Adean, Luiz Da Costa, Julia Gschwend                                        |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Canada        |Lite IDAC                |Stephen Gwyn, Renée Hložek, Wes Fraser                                             |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Croatia       |SPC                      |Tomislav Jurkić, Lovro Palaversa                                                   |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Denmark       |Lite IDAC                |Christa Gall, Radek Wojtak, Hans Kjeldsen                                          |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Japan         |Lite IDAC (x2)           |Hisanori Furusawa, Naoki Yasuda, Masahiro Takada, Satoshi Miyazaki, Yutaka Komiyama|
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Mexico        |Lite IDAC                |Octavio Valenzuela, Luis Arturo Areña-López                                        |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Poland        |Lite IDAC                |Krzysztof Nawrocki, Agniezka Pollo, Pawel, Pietrukowicz                            |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Slovenia      |Lite IDAC                |Andrej Filipčič, Andreja Gomboc                                                    |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|Spain         |Lite IDAC                |Cristóbal Padilla, Ramon Miquel, Nacho Sevilla                                     |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
-|South Korea   |Lite IDAC                |Chang Hee Ree, Narae Hwang, Byeong-Gon Park                                        |
-+--------------+-------------------------+-----------------------------------------------------------------------------------+
+      <style>
+        .ikt-filterbar { display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem; }
+        .ikt-filterbar label { font-size: 0.9em; }
+        .ikt-actionbar { display: flex; flex-wrap: wrap; align-items: center; gap: 1rem; margin-bottom: 1.5rem; }
+        .ikt-actionbar input[type="text"] { flex: 1; min-width: 220px; padding: 0.4em 0.6em; border: 1px solid #999; border-radius: 0.3em; font-size: 0.9em; }
+        .ikt-map-wrap { margin-bottom: 0.5rem; border-radius: 0.5rem; overflow: hidden; background: #eef2f0; }
+        .ikt-map-marker { cursor: pointer; fill-opacity: 0.75; stroke: #ffffff; stroke-width: 0.75; }
+        .ikt-map-marker:hover { stroke: #1a1a1a; stroke-width: 1.5; }
+        .ikt-legend { display: flex; flex-wrap: wrap; gap: 1.2rem; margin-bottom: 1.5rem; font-size: 0.85em; color: #444; }
+        .ikt-legend span { display: inline-flex; align-items: center; gap: 0.4em; }
+        .ikt-legend i { width: 0.8em; height: 0.8em; border-radius: 50%; display: inline-block; }
+        .ikt-idacs-table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
+        .ikt-idacs-table th, .ikt-idacs-table td { text-align: left; padding: 0.5em 0.75em; border-bottom: 1px solid #ddd; }
+        .ikt-idacs-table th { cursor: pointer; user-select: none; white-space: nowrap; }
+        .ikt-idacs-table td.num, .ikt-idacs-table th.num { text-align: right; }
+        .ikt-title-link { color: inherit; text-decoration: none; cursor: pointer; background: none; border: none; padding: 0; font: inherit; text-align: left; }
+        .ikt-title-link:hover { text-decoration: underline; }
+        .ikt-card.ikt-highlight .sd-card { outline: 3px solid #1f4f8b; outline-offset: 2px; transition: outline-color 1.2s ease; }
+      </style>
 
+      <div class="ikt-filterbar">
+        <label>Type
+          <select id="ikt-filter-type">
+            <option value="">All</option>
+            {% for v in all_types %}<option value="type-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Data product
+          <select id="ikt-filter-product">
+            <option value="">All</option>
+            {% for v in all_products %}<option value="product-{{ slugify(v) }}">{{ v }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>GPUs
+          <select id="ikt-filter-gpu">
+            <option value="">All</option>
+            <option value="has-gpu">Offers GPUs</option>
+          </select>
+        </label>
+      </div>
+
+      <div class="ikt-actionbar">
+        <input type="text" id="ikt-search" placeholder="Search countries, institutions, software, use cases...">
+      </div>
+
+      <div class="ikt-map-wrap">
+        <svg viewBox="0 0 1000 500" width="100%" height="360" role="img" aria-label="World map showing IDAC and SPC locations">
+          <rect x="0" y="0" width="1000" height="500" fill="#eef2f0"></rect>
+          {% if world_outline_path %}
+          <path d="{{ world_outline_path }}" fill="#d7ded9" stroke="#c3ccc5" stroke-width="0.5"></path>
+          {% endif %}
+          {% for t in idacs %}
+          {% if t.marker_x is not none %}
+          <circle class="ikt-map-marker" data-slug="{{ t.slug }}" data-tokens="{{ t.filter_tokens }}"
+                  cx="{{ t.marker_x }}" cy="{{ t.marker_y }}" r="{{ t.marker_r }}"
+                  fill="{{ '#1f4f8b' if 'Data Facility' in t.idac_type else ('#1a5c33' if t.idac_type == 'SPC' else '#d35224') }}">
+            <title>{{ t.country }} ({{ t.idac_type }})</title>
+          </circle>
+          {% endif %}
+          {% endfor %}
+        </svg>
+      </div>
+
+      <div class="ikt-legend">
+        <span><i style="background:#1f4f8b"></i> Data Facility (Full IDAC)</span>
+        <span><i style="background:#d35224"></i> Lite IDAC</span>
+        <span><i style="background:#1a5c33"></i> SPC</span>
+        <span style="color:#888">Marker size scales with storage commitment</span>
+      </div>
+
+      <table class="ikt-idacs-table" id="ikt-idacs-table">
+        <thead>
+          <tr>
+            <th data-sort="country">Country</th>
+            <th data-sort="type">Type</th>
+            <th data-sort="location">Host</th>
+            <th class="num" data-sort="storage">Storage<br><small>PB-yr</small></th>
+            <th class="num" data-sort="cpu">CPU<br><small>Mhrs</small></th>
+            <th class="num" data-sort="products">Products</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for t in idacs %}
+          {% set cap = t.capacity or {} %}
+          <tr class="ikt-row" data-tokens="{{ t.filter_tokens }}"
+              data-country="{{ t.country }}"
+              data-type="{{ t.idac_type }}"
+              data-location="{{ t.location.city or '' }}"
+              data-storage="{{ cap.storage_pb_years if cap.storage_pb_years is not none else '' }}"
+              data-cpu="{{ cap.cpu_mhrs if cap.cpu_mhrs is not none else '' }}"
+              data-products="{{ t.product_count }}">
+            <td><button type="button" class="ikt-title-link" data-slug="{{ t.slug }}">{{ t.country }}</button></td>
+            <td>{{ t.idac_type }}</td>
+            <td>{{ t.location.city or 'TBA' }}</td>
+            <td class="num">{{ cap.storage_pb_years if cap.storage_pb_years is not none else 'TBD' }}</td>
+            <td class="num">{{ cap.cpu_mhrs if cap.cpu_mhrs is not none else 'TBD' }}</td>
+            <td class="num">{{ t.product_count }} / {{ t.product_total }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <script>
+      (function () {
+        var SEARCH_INDEX = {{ search_index_json }};
+
+        function matchesSearch(slug) {
+          var query = document.getElementById('ikt-search').value.trim().toLowerCase();
+          if (!query) { return true; }
+          return (SEARCH_INDEX[slug] || '').indexOf(query) !== -1;
+        }
+
+        function setVisible(el, visible) {
+          if (visible) { el.style.removeProperty('display'); }
+          else { el.style.setProperty('display', 'none', 'important'); }
+        }
+
+        function slugOfCard(card) {
+          var m = card.className.match(/\bslug-(\S+)/);
+          return m ? m[1] : '';
+        }
+
+        function applyFilters() {
+          var type = document.getElementById('ikt-filter-type').value;
+          var product = document.getElementById('ikt-filter-product').value;
+          var gpu = document.getElementById('ikt-filter-gpu').value;
+          var filters = [type, product, gpu].filter(Boolean);
+
+          function matches(tokenStr, slug) {
+            var tokens = ' ' + tokenStr + ' ';
+            return filters.every(function (f) { return tokens.indexOf(' ' + f + ' ') !== -1; })
+              && matchesSearch(slug);
+          }
+
+          document.querySelectorAll('.ikt-row').forEach(function (row) {
+            setVisible(row, matches(row.getAttribute('data-tokens'), row.querySelector('.ikt-title-link').getAttribute('data-slug')));
+          });
+          document.querySelectorAll('.ikt-card').forEach(function (card) {
+            setVisible(card, matches(card.className, slugOfCard(card)));
+          });
+          document.querySelectorAll('.ikt-map-marker').forEach(function (marker) {
+            setVisible(marker, matches(marker.getAttribute('data-tokens'), marker.getAttribute('data-slug')));
+          });
+        }
+
+        ['ikt-filter-type', 'ikt-filter-product', 'ikt-filter-gpu'].forEach(function (id) {
+          var el = document.getElementById(id);
+          if (el) { el.addEventListener('change', applyFilters); }
+        });
+        var searchInput = document.getElementById('ikt-search');
+        if (searchInput) { searchInput.addEventListener('input', applyFilters); }
+
+        function scrollToCard(slug) {
+          var card = document.querySelector('.ikt-card.slug-' + CSS.escape(slug));
+          if (!card) { return; }
+          card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          card.classList.add('ikt-highlight');
+          setTimeout(function () { card.classList.remove('ikt-highlight'); }, 1500);
+        }
+
+        document.querySelectorAll('.ikt-title-link').forEach(function (link) {
+          link.addEventListener('click', function () { scrollToCard(link.getAttribute('data-slug')); });
+        });
+        document.querySelectorAll('.ikt-map-marker').forEach(function (marker) {
+          marker.addEventListener('click', function () { scrollToCard(marker.getAttribute('data-slug')); });
+        });
+
+        // Sortable table headers. Numeric columns compare as numbers; blank
+        // (TBD) values always sort to the bottom regardless of direction.
+        var sortState = {};
+        document.querySelectorAll('#ikt-idacs-table th[data-sort]').forEach(function (th) {
+          th.addEventListener('click', function () {
+            var key = th.getAttribute('data-sort');
+            var tbody = document.querySelector('#ikt-idacs-table tbody');
+            var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+            var asc = !sortState[key];
+            sortState = {};
+            sortState[key] = asc;
+            rows.sort(function (a, b) {
+              var av = a.getAttribute('data-' + key) || '';
+              var bv = b.getAttribute('data-' + key) || '';
+              if (av === '' && bv !== '') { return 1; }
+              if (bv === '' && av !== '') { return -1; }
+              var an = parseFloat(av), bn = parseFloat(bv);
+              var cmp;
+              if (!isNaN(an) && !isNaN(bn)) { cmp = an - bn; }
+              else { cmp = av.localeCompare(bv); }
+              return asc ? cmp : -cmp;
+            });
+            rows.forEach(function (r) { tbody.appendChild(r); });
+          });
+        });
+      })();
+      </script>
+
+   .. grid:: 1 1 2 2
+      :gutter: 2
+
+      {% for t in idacs %}
+      {% set cap = t.capacity or {} %}
+      {% set hw = t.hardware or {} %}
+      {% set hwparts = [hw.cpu_architecture, hw.gpu_architecture, hw.storage_type, hw.network] | select | list %}
+      {% set docs = (t.documentation or []) | selectattr('url') | list %}
+      .. grid-item-card:: {{ t.country }}
+          :class-item: ikt-card slug-{{ t.slug }} {{ t.filter_tokens }}
+
+          .. _{{ t.slug }}:
+
+          {{ t.idac_type }} — {{ [t.location.city, t.location.institution] | select | join(', ') }}
+          ^^^
+          {% for p in t.hosted_products %}:bdg-light:`{{ p }}` {% endfor %}{% if cap.gpu_mhrs %}:bdg-success:`GPUs` {% endif %}
+
+          **Capacity (13-yr):** Storage {{ cap.storage_pb_years if cap.storage_pb_years is not none else 'TBD' }} PB-yr · CPU {{ cap.cpu_mhrs if cap.cpu_mhrs is not none else 'TBD' }} Mhrs{% if cap.gpu_mhrs %} · GPU {{ cap.gpu_mhrs }} Mhrs{% endif %}{% if cap.expected_local_users is not none %} · ~{{ cap.expected_local_users }} expected local users{% endif %}
+
+          {% if t.data_releases %}**Data releases:** {% for r in t.data_releases %}:bdg-light:`{{ r }}` {% endfor %}{% endif %}
+
+          {% if hwparts %}**Hardware:** {{ hwparts | join(' · ') }}{% endif %}
+
+          {% if t.software_services %}**Software & services:** {{ t.software_services }}{% endif %}
+
+          {% if t.complementary_datasets %}**Complementary datasets:** {{ t.complementary_datasets }}{% endif %}
+
+          {% if t.use_cases %}**Science use cases:** {{ t.use_cases }}{% endif %}
+
+          {% if t.science_collaboration_agreements %}**Science Collaboration agreements:** {{ t.science_collaboration_agreements }}{% endif %}
+
+          {% if docs %}**Documentation:** {% for d in docs %}`{{ d.title or d.url }} <{{ d.url }}>`__{{ ", " if not loop.last }}{% endfor %}{% endif %}
+
+          {% if t.contacts %}**Contacts:** {% for c in t.contacts %}{{ c.name }}{% if c.email %} (`{{ c.email }} <mailto:{{ c.email }}>`_){% endif %}{{ ", " if not loop.last }}{% endfor %}{% endif %}
+
+          {% if t.notes %}**Notes:** {{ t.notes }}{% endif %}
+          +++
+          {% if 'Data Facility' in t.idac_type %}:bdg-primary:`{{ t.idac_type }}`{% elif t.idac_type == 'SPC' %}:bdg-success:`SPC`{% else %}:bdg-secondary:`{{ t.idac_type }}`{% endif %} :bdg-light:`{{ t.product_count }} / {{ t.product_total }} data products`
+
+      {% endfor %}
 
 What data and services will be available?
 =========================================
 
-`This spreadsheet <https://docs.google.com/spreadsheets/d/1r6JH0_5ROdSZ7I9_N4eSEHGbYgOO2QOwW_70IGo8RSg/edit?usp=sharing>`_ reflects the current plans for the Rubin data, services, and potential use cases to be supported at indivudual IDACs.
+The profiles above are built from the same underlying data as
+`this spreadsheet <https://docs.google.com/spreadsheets/d/1r6JH0_5ROdSZ7I9_N4eSEHGbYgOO2QOwW_70IGo8RSg/edit?usp=sharing>`_,
+which reflects the current plans for the Rubin data, services, and potential use cases to be
+supported at individual IDACs.
 
 What are some potential uses of contributed computing resources?
 ================================================================


### PR DESCRIPTION
Renders the Computing Resources page from per-IDAC YAML via sphinx_jinja, mirroring the Telescope Access page: an inline-SVG world map, filters (type / data product / GPUs), search, a sortable table, and one profile card per IDAC/SPC — no new dependencies or _static assets.

conf.py: adds _load_contributed_idacs() (reuses the existing _to_marker_xy projection + world-outline SVG; markers sized by storage commitment).
contributed-resources.rst: replaces the static Program/Type table with the interactive dashboard.
_data/idacs/: 13 IDAC/SPC records imported from knutago/idac-dashboard, tagged with idac_type.
Builds clean with documenteer[guide]; pre-commit passes. A branch preview should deploy at in-kind-program.lsst.io/v/u/knutago/idac-computing-resources-dashboard/contribution-types/contributed-resources.html.