### PR TITLE
Fix Show more button, restore Contributions subtype nesting

### DIFF
--- a/docs/contribution-types/contributed-software.rst
+++ b/docs/contribution-types/contributed-software.rst
@@ -97,7 +97,14 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
       </table>
 
       <script>
-      (function () {
+      document.addEventListener('DOMContentLoaded', function () {
+        // Deferred to DOMContentLoaded: this script tag renders above the
+        // `.. grid::` block below, which is where the cards (and their
+        // Show more/Show less buttons) actually live in the page source.
+        // An inline <script> runs the instant the parser reaches it, so
+        // querying for card elements here immediately (rather than after
+        // the whole page has parsed) would always find zero of them --
+        // that's why the expand button did nothing.
         var SEARCH_INDEX = {{ search_index_json }};
         var CID_RE = /cid-([a-z0-9-]+)/;
 
@@ -183,7 +190,7 @@ Please email the in-kind helpdesk rubin-inkind at noirlab dot edu if you have an
             rows.forEach(function (r) { tbody.appendChild(r); });
           });
         });
-      })();
+      });
       </script>
 
    .. grid:: 1 1 2 2

--- a/docs/contribution-types/index.rst
+++ b/docs/contribution-types/index.rst
@@ -11,20 +11,12 @@ The Vera C. Rubin Observatory In-Kind Program spans a wide range of contribution
 
 Further information is available about the following contributions:
 
-- :doc:`General Pool <general-pool>` -- directable software-development effort offered without a recipient group defined ahead of time, drawn on by any Rubin team or LSST Science Collaboration with an unmet need.
-- :doc:`Datasets <contributed-datasets>` -- complementary data products that partners make available to the Rubin community.
-- :doc:`Software <contributed-software>` -- directable and non-directable software-development effort contributed to Rubin teams and LSST Science Collaborations.
-- :doc:`Telescope Access <contributed-telescope>` -- observing time at partner facilities, made available each semester via the NOIRLab Call for Proposals.
-- :doc:`Computing Resources <contributed-resources>` -- Independent Data Access Centers (IDACs), Scientific Processing Centers (SPCs), and other computing, storage, and data infrastructure contributed to the Rubin community.
-
-
 .. raw:: html
 
    <div class="subindex-toc-hidden">
 
 .. toctree::
    :maxdepth: 1
-   :hidden:
 
    general-pool
    contributed-datasets


### PR DESCRIPTION
Two site bugs:

1. The "Show more"/"Show less" button on Contributed Software cards never worked — its click handler was set up in a <script> block that runs before the .. grid:: directive containing the cards even renders, so it was attaching listeners to zero elements. Fixed by deferring setup to DOMContentLoaded.
2. The contribution subtypes (General Pool, Datasets, Software, Telescope Access, Computing Resources) had disappeared from the site's generated structure — sidebar nesting, top nav, and the main landing page — since an earlier commit marked contribution-types/index.rst's own toctree :hidden:, breaking its parent/child relationship with those five pages. Un-hid it and removed the prose list that had been standing in for it, restoring the real hierarchy everywhere at once rather than patching each symptom separately.